### PR TITLE
GO: make guardian header blue

### DIFF
--- a/data/gear-optimizer/buff.yaml
+++ b/data/gear-optimizer/buff.yaml
@@ -105,9 +105,11 @@
     extraCSS: "text-guardian"
 
 - SECTION: >
-    Guardian
-    <span data-armory-size="24" data-armory-embed="traits" data-armory-ids="579"></span>
-    Perfect Inscriptions (Assuming 100% uptime!)
+    <span class="text-guardian">
+      Guardian
+      <span data-armory-size="24" data-armory-embed="traits" data-armory-ids="579"></span>
+      Perfect Inscriptions (Assuming 100% uptime!)
+    </span>
 
   bane-signet:
     text: "Bane Signet"


### PR DESCRIPTION
**old.discretize.eu**: This makes the header for the perfect inscriptions buff section blue like it used to be.

Mostly this is just a test to see how updating a file in a submodule works.