### PR TITLE
GO: switch buff modifiers to flat when it's irrelevant

### DIFF
--- a/data/gear-optimizer/buff.yaml
+++ b/data/gear-optimizer/buff.yaml
@@ -14,7 +14,7 @@
       <span class="icon icon-fury"></span>
       Fury
     modifiers:
-      buff: { "Critical Chance": 20 }
+      flat: { "Critical Chance": 20 }
     default-enabled: true
 
   protection:
@@ -56,7 +56,8 @@
   banner-of-tactics:
     text: "Banner of Tactics"
     modifiers:
-      buff: { "Healing Power": 100, "Boon Duration": 10 }
+      buff: { "Healing Power": 100}
+      flat: { "Boon Duration": 10 }
     gw2-id: 14408
     armory-type: "skills"
     extraCSS: "text-warrior"
@@ -131,7 +132,7 @@
   signet-of-mercy:
     text: "Signet of Mercy"
     modifiers:
-      buff: { "Boon Duration": 10 }
+      flat: { "Boon Duration": 10 }
     gw2-id: 9163
     armory-type: "skills"
     extraCSS: "text-guardian"
@@ -158,7 +159,7 @@
   facet-of-nature:
     text: "Facet of Nature—Dragon"
     modifiers:
-      buff: { "Boon Duration": 20 }
+      flat: { "Boon Duration": 20 }
     gw2-id: 29371
     armory-type: "skills"
     extraCSS: "text-revenant"

--- a/data/gear-optimizer/elementalist.yaml
+++ b/data/gear-optimizer/elementalist.yaml
@@ -46,7 +46,8 @@
   frost-bow:
     text: "Frost Bow <small>when equipped</small>"
     modifiers:
-      buff: { "Healing Power": 180, "Condition Duration": 20 }
+      buff: { "Healing Power": 180 }
+      flat: { "Condition Duration": 20 }
     gw2-id: 5567
     armory-type: "skills"
 
@@ -64,7 +65,7 @@
   burning-precision:
     text: "Burning Precision"
     modifiers:
-      buff: { "Burning Duration": 20 }
+      flat: { "Burning Duration": 20 }
     gw2-id: 296
     armory-type: "traits"
 
@@ -168,7 +169,7 @@
     text: "Serrated Stones"
     modifiers:
       multiplier: { "Effective Power": 0.05 }
-      buff: { "Bleeding Duration": 20 }
+      flat: { "Bleeding Duration": 20 }
     gw2-id: 1507
     armory-type: "traits"
 
@@ -277,7 +278,7 @@
   superior-elements:
     text: "Superior Elements <small>100% uptime</small>"
     modifiers:
-      buff: { "Critical Chance": 10 }
+      flat: { "Critical Chance": 10 }
     gw2-id: 2177
     armory-type: "traits"
 
@@ -300,7 +301,7 @@
     text: "Weaver's Prowess <small>100% uptime</small>"
     modifiers:
       multiplier: { "add: Effective Condition Damage": 0.1 }
-      buff: { "Condition Duration": 20 }
+      flat: { "Condition Duration": 20 }
     gw2-id: 2180
     armory-type: "traits"
 

--- a/data/gear-optimizer/engineer.yaml
+++ b/data/gear-optimizer/engineer.yaml
@@ -47,14 +47,14 @@
   high-caliber:
     text: "High Caliber"
     modifiers:
-      buff: { "Critical Chance": 15 }
+      flat: { "Critical Chance": 15 }
     gw2-id: 1914
     armory-type: "traits"
 
   hematic-focus:
     text: "Hematic Focus"
     modifiers:
-      buff: { "Critical Chance": 10 }
+      flat: { "Critical Chance": 10 }
     gw2-id: 536
     armory-type: "traits"
 

--- a/data/gear-optimizer/guardian.yaml
+++ b/data/gear-optimizer/guardian.yaml
@@ -119,7 +119,7 @@
   radiant-fire:
     text: "Radiant Fire"
     modifiers:
-      buff: { "Burning Duration": 20 }
+      flat: { "Burning Duration": 20 }
     gw2-id: 567
     armory-type: "traits"
 
@@ -133,7 +133,8 @@
   radiant-power:
     text: "Radiant Power"
     modifiers:
-      buff: { "Critical Chance": 10, "Ferocity": 150 }
+      flat: { "Critical Chance": 10 }
+      buff: { "Ferocity": 150 }
     gw2-id: 568
     armory-type: "traits"
 
@@ -147,7 +148,7 @@
   righteous-instincts:
     text: "Righteous Instincts"
     modifiers:
-      buff: { "Critical Chance": 25 }
+      flat: { "Critical Chance": 25 }
     gw2-id: 1683
     armory-type: "traits"
 
@@ -217,7 +218,7 @@
   virtue-of-retribution:
     text: "Virtue of Resolution"
     modifiers:
-      buff: { "Retaliation Duration": 25 }
+      flat: { "Retaliation Duration": 25 }
     gw2-id: 604
     armory-type: "traits"
 

--- a/data/gear-optimizer/mesmer.yaml
+++ b/data/gear-optimizer/mesmer.yaml
@@ -114,7 +114,7 @@
   danger-time:
     text: "Danger Time"
     modifiers:
-      buff: { "Critical Chance": 15 }
+      flat: { "Critical Chance": 15 }
     gw2-id: 2009
     armory-type: "traits"
 

--- a/data/gear-optimizer/ranger.yaml
+++ b/data/gear-optimizer/ranger.yaml
@@ -49,7 +49,7 @@
   hunters-tactics:
     text: "Hunter's Tactics"
     modifiers:
-      buff: { "Critical Chance": 10 }
+      flat: { "Critical Chance": 10 }
       multiplier: { "Effective Power": 0.1 }
     gw2-id: 1068
     armory-type: "traits"
@@ -58,14 +58,15 @@
     text: "Light on your Feet <small>100% uptime</small>"
     modifiers:
       multiplier: { "Effective Power": 0.1 }
-      buff: { "Condition Duration": 10 }
+      flat: { "Condition Duration": 10 }
     gw2-id: 1912
     armory-type: "traits"
 
   vicious-quarry:
     text: "Vicious Quarry"
     modifiers:
-      buff: { "Ferocity": 250, "Critical Chance": 10 }
+      buff: { "Ferocity": 250 }
+      flat: { "Critical Chance": 10 }
     gw2-id: 1888
     armory-type: "traits"
 
@@ -189,7 +190,7 @@
     text: "Oppressive Superiority"
     modifiers:
       multiplier: { "Effective Power": 0.1 }
-      buff: { "Condition Duration": 10 }
+      flat: { "Condition Duration": 10 }
     gw2-id: 2143
     armory-type: "traits"
 

--- a/data/gear-optimizer/revenant.yaml
+++ b/data/gear-optimizer/revenant.yaml
@@ -24,14 +24,14 @@
   pact-of-pain:
     text: "Pact of Pain"
     modifiers:
-      buff: { "Condition Duration": 15 }
+      flat: { "Condition Duration": 15 }
     gw2-id: 1714
     armory-type: "traits"
 
   yearning-empowerment:
     text: "Yearning Empowerement"
     modifiers:
-      buff: { "Condition Duration": 10 }
+      flat: { "Condition Duration": 10 }
     gw2-id: 1744
     armory-type: "traits"
 
@@ -84,7 +84,7 @@
   roiling-mists:
     text: "Roiling Mists"
     modifiers:
-      buff: { "Critical Chance": 20 }
+      flat: { "Critical Chance": 20 }
     gw2-id: 1719
     armory-type: "traits"
 
@@ -175,7 +175,7 @@
   blood-fury:
     text: "Blood Fury"
     modifiers:
-      buff: { "Bleeding Duration": 25 }
+      flat: { "Bleeding Duration": 25 }
     gw2-id: 2079
     armory-type: "traits"
 
@@ -189,7 +189,7 @@
   brutal-momentum:
     text: "Brutal Momentum"
     modifiers:
-      buff: { "Critical Chance": 33 }
+      flat: { "Critical Chance": 33 }
     gw2-id: 2142
     armory-type: "traits"
 

--- a/data/gear-optimizer/warrior.yaml
+++ b/data/gear-optimizer/warrior.yaml
@@ -112,7 +112,7 @@
   bloodlust:
     text: "Bloodlust"
     modifiers:
-      buff: { "Bleeding Duration": 33 }
+      flat: { "Bleeding Duration": 33 }
     gw2-id: 1337
     armory-type: "traits"
 
@@ -281,7 +281,7 @@
   king-of-fires:
     text: "King of Fires"
     modifiers:
-      buff: { "Burning Duration": 33 }
+      flat: { "Burning Duration": 33 }
     gw2-id: 2038
     armory-type: "traits"
 


### PR DESCRIPTION
Because nothing in this game converts [thing which is not a stat point value] to [whatever], it makes no difference whether these bonuses are tagged "flat" or "buff." Flat modifiers perform (very) slightly better.