### PR TITLE
GO: add exposed and low armor and fix impact/slaying

### DIFF
--- a/data/gear-optimizer/buff.yaml
+++ b/data/gear-optimizer/buff.yaml
@@ -171,3 +171,21 @@
     gw2-id: 27975
     armory-type: "skills"
     extraCSS: "text-revenant"
+
+- SECTION: "Effects"
+
+  exposed:
+    text: >
+      <span class="icon icon-exposed"></span>
+      Exposed
+      <small class="text-muted font-italic">(100% uptime)</small>
+    modifiers:
+      multiplier: { "Effective Power": 0.3, "Effective Condition Damage": 1.0 }
+
+  low-armor:
+    text: >
+      Low Boss Armor (VG, KC)
+      <small class="text-muted font-italic">1910 vs 2597</small>
+    modifiers:
+      multiplier: { "Effective Power": 0.359685864 }
+

--- a/data/gear-optimizer/buff.yaml
+++ b/data/gear-optimizer/buff.yaml
@@ -30,7 +30,7 @@
       Vulnerability
       <small class="text-muted font-italic">(25x)</small>
     modifiers:
-      multiplier: { "Effective Power": 0.25, "Effective Condition Damage": 0.25 }
+      multiplier: { "target: Effective Power": 0.25, "target: Effective Condition Damage": 0.25 }
     default-enabled: true
 
 - SECTION: ""
@@ -180,7 +180,7 @@
       Exposed
       <small class="text-muted font-italic">(100% uptime)</small>
     modifiers:
-      multiplier: { "Effective Power": 0.3, "Effective Condition Damage": 1.0 }
+      multiplier: { "target: Effective Power": 0.3, "target: Effective Condition Damage": 1.0 }
 
   low-armor:
     text: >

--- a/data/gear-optimizer/sigils.yaml
+++ b/data/gear-optimizer/sigils.yaml
@@ -19,7 +19,7 @@
       Superior Sigil of the Night/Impact/Slaying<br>
       <small class="text-muted font-italic">(Both 7%/3%)</small>
     modifiers:
-      multiplier: { "add: Effective Power": 0.1 }
+      multiplier: { "add: Effective Power": 0.03, "Effective Power": 0.07 }
     gw2-id: 36053
     armory-type: "items"
 


### PR DESCRIPTION
Adds buff effects for exposed and low boss armor

Slaying/impact 7% is apparently multiplicative:
https://discord.com/channels/301270513093967872/842629146857177098/866660090449887272

- [x] have someone verify if exposed condi bonus is multiplicative (most are additive, but vuln isn't, and this being a condition on enemy it's probably fine)