### PR TITLE
MDX fixes

### DIFF
--- a/builds/elementalist/condi-weaver/index.md
+++ b/builds/elementalist/condi-weaver/index.md
@@ -277,6 +277,7 @@ date: 2021-09-18T23:21:57.325Z
 <Grid>
 <GridItem xs="12" sm="12">
 <Card title="Disclaimer">
+
 Golem rotations out of the raid builds are generally suboptimal in fractals due to <Effect name="Exposed"/> and phases being much shorter compared to raids. The raid rotations are optimized for sustained DPS while in fractals a player needs the ability to adapt a rotation to the amount of time a group needs to finish a phase.  
 </Card>
 </GridItem>
@@ -312,119 +313,147 @@ If you have an extra set of weapons (or legendary sigils), you can also precast 
 <Skill name="Air Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Weave Self"/>
 2. <Skill name="Signet of Fire"/>
 3. <Skill name="Gale Strike"/>
 4. <Skill name="Magnetic Wave"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Air Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Flame Uprising"/>
 2. <Skill name="Pyro Vortex"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Transmute Fire"/>
 2. <Skill name="Cauterizing Strike"/>   
 3. <Skill name="Flamewall"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Lava Skin"/>
 2. <Skill name="Earthen Vortex"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Rust Frenzy"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Flame Uprising"/>
 2. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Searing Slash"/>
 2. <Skill name="Transmute Fire"/>
 3. <Skill name="Signet of Fire"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Air Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Pyro Vortex"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Air Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Flame Uprising"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Cauterizing Strike"/>
 2. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Searing Slash"/>
 2. <Skill name="Transmute Fire"/>
 3. <Skill name="Flamewall"/>
 4. <Skill name="Earthen Vortex"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Water Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Natural Frenzy"/>
 2. <Skill name="Magnetic Wave"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Water Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Flame Uprising"/>
 2. <Skill name="Signet of Fire"/>
 3. <Skill name="Twin strike"/>
-4. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/> 
+4. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Transmute Fire"/>
 2. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
 3. <Skill name="Cauterizing Strike"/>
 4. <Skill name="Flame Uprising"/>
+
 </GridItem>
 </Card>
 
@@ -458,127 +487,153 @@ If you have an extra set of weapons (or legendary sigils), you can also precast 
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Lava Skin"/>
 2. <Skill name="Earthen Vortex"/>
 3. <Skill name="Crystal Slash"/> => <Skill name="Crystalline Strike"/> => <Skill name="Crystalline Sunder"/>
 4. <Skill name="Transmute Fire"/>
 5. <Skill name="Flamewall"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Signet of Fire"/>
 2. <Skill name="Rust Frenzy"/>
 3. <Skill name="Crystal Slash"/> => <Skill name="Crystalline Strike"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Crystalline Sunder"/>
 2. <Skill name="Flame Uprising"/> + <Skill name="Magnetic Wave"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Transmute Fire"/>
 2. <Skill name="Cauterizing Strike"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
 4. <Skill name="Flame Uprising"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Air Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Signet of Fire"/>
 2. <Skill name="Pyro Vortex"/>
 3. <Skill name="Charged Strike"/> => <Skill name="Polaric Slash"/> => <Skill id="45216"/>
 4. <Skill name="Flamewall"/>
 5. <Skill name="Transmute Fire"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Air Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
 2. <Skill name="Flame Uprising"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Searing Slash"/>
 2. <Skill name="Lava Skin"/>
 3. <Skill name="Earthen Vortex"/>
 4. <Skill name="Crystal Slash"/> => <Skill name="Crystalline Strike"/> => <Skill name="Crystalline Sunder"/>
 5. <Skill name="Transmute Fire"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Signet of Fire"/> + <Skill name="Magnetic Wave"/>
 2. <Skill name="Rust Frenzy"/>
 3. <Skill name="Crystal Slash"/> => <Skill name="Crystalline Strike"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Earth Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Crystalline Sunder"/>
 2. <Skill name="Flame Uprising"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/> x2
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Transmute Fire"/>
 2. <Skill name="Flamewall"/>
 3. <Skill name="Cauterizing Strike"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
 4. <Skill name="Flame Uprising"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Air Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Signet of Fire"/>
 2. <Skill name="Pyro Vortex"/>
 3. <Skill name="Charged Strike"/> => <Skill name="Polaric Slash"/> => <Skill id="45216"/>
 4. <Skill name="Transmute Fire"/>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Fire Attunement" size="large" disableText/> <Skill name="Air Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> => <Skill name="Searing Slash"/>
 2. <Skill name="Flame Uprising"/>
 3. <Skill name="Fire strike"/> => <Skill name="Fire Swipe"/> =>
+
 </GridItem>
 
 <GridItem sm="3">
 <Skill name="Earth Attunement" size="large" disableText/> <Skill name="Fire Attunement" size="large" disableText/>
 </GridItem>
 <GridItem sm="10">
+
 1. <Skill name="Searing Slash"/>
 2. <Skill name="Lava Skin"/>
 3. <Skill name="Earthen Vortex"/>
+
 </GridItem>
 </Card>
 </GridItem>

--- a/builds/elementalist/power-weaver/index.md
+++ b/builds/elementalist/power-weaver/index.md
@@ -600,6 +600,7 @@ Tempest precasting build template:
 
 <GridItem xs="12" sm="12">
 <Card title="Rotation (Bolt to the Heart)">
+
 The general idea is to loop between <Skill name="Air Attunement" disableText/>/<Skill name="Air Attunement" disableText/> and <Skill name="Fire Attunement" disableText/>/<Skill name="Fire Attunement" disableText/> using your strongest skills like <Skill name="Invoke Lightning"/> in Fire with <Trait name="Elements of Rage"/> up.
 
 <Grid>
@@ -608,6 +609,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Lightning Storm"/>
 
 2.  <Skill name="Quantum Strike"/>
@@ -619,6 +621,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Pyro Vortex"/>
 
 2.  <Skill name="Ride the Lightning"/>
@@ -637,6 +640,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Invoke Lightning"/>   \
     <Label>Only if pre-casted LH</Label>
 
@@ -656,6 +660,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Ring of Fire"/>
 
 2.  <Skill name="Charged Strike"/> => <Skill name="Polaric Slash"/> => <Skill name="Call Lightning" profession="elementalist"/>
@@ -669,6 +674,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Charged Strike"/> => <Skill name="Polaric Slash"/> => <Skill name="Call Lightning" profession="elementalist"/>
 
 2.  <Skill name="Quantum Strike"/>
@@ -680,6 +686,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Pyro Vortex"/>
 
 2.  <Skill name="Ride the Lightning"/>
@@ -695,6 +702,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Fiery Rush"/>
 
 2.  <Skill name="Firestorm"/>
@@ -714,6 +722,7 @@ The general idea is to loop between <Skill name="Air Attunement" disableText/>/<
 </GridItem>
 
 <GridItem sm="10">
+
 1.  <Skill name="Charged Strike"/> => <Skill name="Polaric Slash"/> => <Skill name="Call Lightning" profession="elementalist"/>
 
 2.  <Skill name="Fire Grab"/>

--- a/builds/guardian/condi-firebrand/index.md
+++ b/builds/guardian/condi-firebrand/index.md
@@ -381,6 +381,7 @@ benchmark:
 <Card title="Rotation">
 
 <Warning>
+
 **Make sure to only press <Skill id="9089"/> three times (twice to throw the projectile and once to activate the skill initially) or you will cancel a wasted cast! Never interrupt your axe auto attack chain! Keep <Skill name="purgingflames"/> on cooldown!**
 </Warning>
 
@@ -439,6 +440,7 @@ When <Skill name="Tome of Justice"/> is off cd you just repeat this rotation.
 <Card title="Precasting">
 
 <Warning>
+
 The most important part is to get the precast of Ashes of the Just right! You have to start the fight quickly to not lose the stacks since they only last 10 seconds!
 </Warning>
 

--- a/builds/guardian/power-dragonhunter/index.md
+++ b/builds/guardian/power-dragonhunter/index.md
@@ -376,6 +376,7 @@ If you have a Mistlock Singularity present you can use these skills for precasts
 
 <GridItem xs="12" sm="6">
 <Card title="Notes on skill usage:">
+
 -   Always start on sword
 
 - Delay swapping to GS until the CC-bar is about to be broken. This is especially important at Ensolyss without instant CC.

--- a/builds/guardian/power-firebrand/index.md
+++ b/builds/guardian/power-firebrand/index.md
@@ -18,7 +18,7 @@ sections:
 
       <Warning>
 
-      Its worth mentioning that \*<Specialization text="Power Quickness Firebrand" name="Firebrand"/>\* is exceedingly strong when bosses phase quickly. For various T4 fractals, long fights or if you happen to be in a slower group (most PuG groups), you want to run \*<BuildLink build="Condi Firebrand" specialization="Firebrand"/>\* as it provides much higher sustained DPS.
+      Its worth mentioning that <Specialization text="Power Quickness Firebrand" name="Firebrand"/> is exceedingly strong when bosses phase quickly. For various T4 fractals, long fights or if you happen to be in a slower group (most PuG groups), you want to run <BuildLink build="Condi Firebrand" specialization="Firebrand"/> as it provides much higher sustained DPS.
 
       </Warning>
   - type: equipment
@@ -61,7 +61,7 @@ sections:
       - Greatswords, Scepters, Swords with <Item name="Night" type="Sigil" disableText/>/<Item name="impact" type="Sigil" disableText/> and <Item name="Serpent Slaying" type="Sigil" disableText/>/<Item name="Impact" type="Sigil" disableText/>
 
 
-      - Greatswords and foci with (see \[Cheat Sheet]\(/guides/cheat-sheet))
+      - Greatswords and foci with (see [Cheat Sheet](/guides/cheat-sheet))
 
 
       - Maces for symbol precast
@@ -473,14 +473,14 @@ For that reason you can find a video with openers, that are efficient to use her
 
 <Card title="Firebrand openers">
 
-<Video caption="by MagicBot \[dT], edited by Vince \[dT]" youtube="pFUHvaqPOO0"/>
+<Video caption="by MagicBot [dT], edited by Vince [dT]" youtube="pFUHvaqPOO0"/>
 </Card>
 </GridItem>
 
 <GridItem xs="12" sm="6">
 <Card title="Precasting">
 
-If you have a \_Mistlock Singularity\_ present you can use these skills for precasts:
+If you have a _Mistlock Singularity_ present you can use these skills for precasts:
 
 1.  Cast <Skill name="tome of justice"/> skill 4 and 5
 
@@ -494,7 +494,7 @@ If you have a \_Mistlock Singularity\_ present you can use these skills for prec
 
 6.  Use <Skill name="banesignet"/>
 
-7.  Take \_Mistlock Singularity\_
+7.  Take _Mistlock Singularity_
 
 8.  Use <Skill name="Feelmywrath"/>
 
@@ -538,7 +538,7 @@ If you have a \_Mistlock Singularity\_ present you can use these skills for prec
 <GridItem xs="12" sm="6">
 <Card title="Golem Rotation">
 
-<Video youtube="G1Y1u4ZwJh8" caption="MajesticNoodle \[BATS]"/>
+<Video youtube="G1Y1u4ZwJh8" caption="MajesticNoodle [BATS]"/>
 </Card>
 </GridItem>
 </Grid>

--- a/builds/guardian/seraph-firebrand/index.md
+++ b/builds/guardian/seraph-firebrand/index.md
@@ -150,7 +150,7 @@ sections:
       </Warning>
 
 
-      The rotation is a **lot** simpler compared to any other <Specialization name="Guardian"/> build (except for HFB where your weapons do not have immediate effect on how efficient the build is). However, weapon swaps require careful consideration, because it is not efficient to be stuck on staff or to have less than 25 <Boon name="might"/> during a damage phase.\
+      The rotation is a **lot** simpler compared to any other <Specialization name="Guardian"/> build (except for HFB where your weapons do not have immediate effect on how efficient the build is). However, weapon swaps require careful consideration, because it is not efficient to be stuck on staff or to have less than 25 <Boon name="might"/> during a damage phase.
 
       Getting the weapon swaps right is probably the hardest part (more info below). Generally, it is recommended to always camp Axe/Torch and only swap to staff to use <Skill name="Empower"/> to top up <Boon name="Might"/>.
 

--- a/builds/ranger/condi-soulbeast/index.md
+++ b/builds/ranger/condi-soulbeast/index.md
@@ -515,7 +515,7 @@ As a <Specialization name="Soulbeast" text="Condi Soulbeast"/> we have three imp
 
 **<Skill name="Crippling Shot"/> -** Can be precasted giving you the effect _Blood Thirst_ lasting for 11 seconds. When you have this effect and are merged your next 3 attacks will inflict 1 stack of <Condition name="Bleeding"/> lasting for 12 seconds.
 
-**<Skill name="Double Arc"/> -** Can be precasted giving you the effect +Poisonous Strike\_ lasting for 7 seconds. When you have this effect and are merged your next 2 attacks will inflict 1 stack of <Condition name="poisoned" text ="Poison"/> lasting for 6 seconds. This skill can be used twice giving you 3 charges.
+**<Skill name="Double Arc"/> -** Can be precasted giving you the effect _Poisonous Strike_ lasting for 7 seconds. When you have this effect and are merged your next 2 attacks will inflict 1 stack of <Condition name="poisoned" text ="Poison"/> lasting for 6 seconds. This skill can be used twice giving you 3 charges.
 </Card>
 
 </GridItem>

--- a/builds/revenant/power-renegade/index.md
+++ b/builds/revenant/power-renegade/index.md
@@ -839,8 +839,7 @@ benchmark:
 <GridItem xs="12" sm="6">
 <Card title="Information">
 
-Golem rotations out of the raid builds are generally suboptimal in fractals due to <Effect name="Exposed"/> and phases being much shorter compared to raids. The raid rotations are optimized for sustained DPS while in fractals a player needs the ability to adapt a rotation to the amount of time a group needs to finish a phase.
-
+Golem rotations out of the raid builds are generally suboptimal in fractals due to <Effect name="Exposed"/> and phases being much shorter compared to raids. The raid rotations are optimized for sustained DPS while in fractals a player needs the ability to adapt a rotation to the amount of time a group needs to finish a phase.\
 For that reason you can find a video with openers, that are efficient to use here.
 </Card>
 
@@ -852,6 +851,7 @@ For that reason you can find a video with openers, that are efficient to use her
 
 <GridItem xs="12" sm="6">
 <Card title="Dealing with No Pain, No Gain">
+
 There are multiple weapons in your arsenal to deal with the instability <Instability name="No Pain, No Gain"/> and make it easier to manage the boons that the enemy will receive from this instability. For fractals with <Instability name="No Pain, No Gain"/> it is recommended to run a staff with <Item id="72872"/> instead of a <Item id="24615"/>. The <Item id="72872"/> will transfer three boons from enemies to you when you interrupt an attack. For enemies with a defiance bar, using a CC skill while the enemy is casting any ability counts as interrupting, even if there is no "*interrupted*" message.
 
 <Weapons weapon1MainType="Staff" weapon1MainAffix="Diviner" weapon1MainSigil1="Severance" weapon1MainSigil2="Absorption" unembossed/>

--- a/builds/thief/condi-deadeye/index.md
+++ b/builds/thief/condi-deadeye/index.md
@@ -316,6 +316,7 @@ benchmark:
 <Card title="Rotation">
 
 <Warning>
+
 **Make sure to only press <Skill name="mercy"/> *after* completing <Skill name="malicioussneakattack"/> !**
 </Warning>
 
@@ -327,12 +328,14 @@ benchmark:
 
 4.  **<Skill name="Repeater"/> Three times** (Pistol 3)
 
-5.  **One Stealth Ability**\*
+5.  **One Stealth Ability**
 
 6.  <Skill name="malicioussneakattack"/>
 
 <Warning>
-\***Stealth abilities priority: <Skill name="stealtime"/> > <Skill name="hideinshadows"/> > <Skill name="shadowmeld"/> > <Skill name="cloakanddagger"/>(only if <Skill name="deadeyesmark"/> is coming off cooldown).**
+
+**Stealth abilities priority: <Skill name="stealtime"/> > <Skill name="hideinshadows"/> > <Skill name="shadowmeld"/> > <Skill name="cloakanddagger"/> (only if <Skill name="deadeyesmark"/> is coming off cooldown).**
+
 </Warning>
 
 **Repeat from 2.** Use <Skill name="deadeyesmark"/>, <Skill name="skalevenom"/> and <Skill name="spidervenom"/> whenever these abilities go off cooldown.
@@ -347,7 +350,7 @@ benchmark:
 
 <Card title="Precasting">
 
-All Damaging Venom Skills should be casted on the _Mistlock Singularity_:<Skill name="Skale Venom"/>, <Skill name="Spider Venom"/> and <Skill name="Devourer Venom"/>. On stationary bosses which can be manually activated, instead of precasting <Skill name="Devourer Venom"/>, you can instead go to the spawn location and precast <Skill name="preparethousandneedles"/>. All you have to do then is to activate the Preparation when the boss becomes vulnerable, and cast it again as it will be off cooldown.
+All Damaging Venom Skills should be casted on the _Mistlock Singularity_: <Skill name="Skale Venom"/>, <Skill name="Spider Venom"/> and <Skill name="Devourer Venom"/>. On stationary bosses which can be manually activated, instead of precasting <Skill name="Devourer Venom"/>, you can instead go to the spawn location and precast <Skill name="preparethousandneedles"/>. All you have to do then is to activate the Preparation when the boss becomes vulnerable, and cast it again as it will be off cooldown.
 
 1.  Spam <Skill name="clusterbomb"/> for <Boon name="might"/> blasts on the _Mistlock Singularity_.
 

--- a/cm-guides/elementalist/power-weaver/index.md
+++ b/cm-guides/elementalist/power-weaver/index.md
@@ -9,6 +9,7 @@ disableBosses: ['LightAi', 'DarkAi']
 
 <ConditionalComponent condition="pug">
 <Boss name="MAMA" video="KlTuxWA9uKE" videoCreator="Elda [dT]" foodId="43360" utilityId="50082" heal="glyphofelementalharmony" utility1="arcaneblast" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 This version is made mostly for PuGs that are not phasing fast enough to get profit from <Skill id="44612"/>. If group is good you can follow the organised rotation and just add <Skill id="5687"/> at start of the boss for cc (it will be up for phase 3). Precast <Skill id="40183"/> for 1 tick in <Skill id="5494"/>/<Skill id="5494"/> at the beginning of each phase.
 </Boss>
 
@@ -94,6 +95,7 @@ This version is made mostly for PuGs that are not phasing fast enough to get pro
 <ConditionalComponent condition="static">
 <Boss name="MAMA" video="WFYMOt5gf_4" videoCreator="KalzeN [dT]" foodId="43360" utilityId="50082" heal="glyphofelementalharmony" utility1="unravel" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
 <Warning>
+
 This build only works if you kill MAMA in less than 55 seconds. If there is any doubt about the kill time, go with the PuG version. The following guide assumes you are following the proposed [CC-Distribution](/guides/cc-distribution).
 </Warning>
 
@@ -177,6 +179,7 @@ In more organised groups it's recommended to run <Specialization name="Tempest"/
 
 <ConditionalComponent condition="pug">
 <Boss name="siax" video="XnTBfLMMic4" videoCreator="KalzeN [dT]" foodId="43360" utilityId="50082" heal="glyphofelementalharmony" utility1="arcaneblast" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="serpentslaying" weapon1OffInfusionId="37131">
+
 This version is made mostly for pugs that are not phasing fast enough to profit from <Skill id="44612"/> and where you have to solo your add. Use <Skill id="40183"/> slightly delayed to get more <Condition name="Burning"/> ticks.
 </Boss>
 
@@ -228,6 +231,7 @@ This version is made mostly for pugs that are not phasing fast enough to profit 
 <ConditionalComponent condition="static">
 <Boss name="siax" video="toqlXSTRSVg" videoCreator="KalzeN [dT]" foodId="43360" utilityId="50082" heal="signetofrestoration" utility1="unravel" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="serpentslaying" weapon1OffInfusionId="37131">
 <Warning>
+
 This build only works if you kill Siax in less than 55 seconds. If there is any doubt about the kill time, go with the PuG version.
 </Warning>
 
@@ -289,6 +293,7 @@ In more organised groups it's recommended to run <Specialization name="Tempest"/
 
 <ConditionalComponent condition="pug">
 <Boss name="ensolyss" video="dAn5Uy0--hc" timestamp="" videoCreator="Elda [dT]" foodId="41569" utilityId="50082" heal="glyphofelementalharmony" utility1="arcaneblast" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="serpentslaying" weapon1OffInfusionId="37131">
+
 If group DPS is low its recommended to run <Trait id="214"/> instead of <Trait id="1502"/>. In PuGs it is recommended to use the raid rotation from Snow Crows.Use <Skill id="40183"/> precasted for instant <Condition name="Vulnerability"/>. If phases are long try to use next ones in <Skill id="5492"/>/<Skill id="5494"/> -> <Skill id="5492"/>/<Skill id="5492"/> to get more burning stacks. Spam your <Skill id="5539"/> during <Effect name="Exposed"/> window.
 </Boss>
 
@@ -348,6 +353,7 @@ If group DPS is low its recommended to run <Trait id="214"/> instead of <Trait i
 
 <ConditionalComponent condition="static">
 <Boss name="ensolyss" video="0mmm-CBLrn8" videoCreator="KalzeN [dT]" foodId="41569" utilityId="50082" heal="arcanebrilliance" utility1="arcaneblast" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="serpentslaying" weapon1OffInfusionId="37131">
+
 Use first <Skill id="40183"/> precasted for instant <Condition name="Vulnerability"/>, if phases are long try to use the next ones in <Skill id="5492"/>/<Skill id="5494"/> -> <Skill id="5492"/>/<Skill id="5492"/> to get more <Condition name="Burning"/> stacks.
 </Boss>
 
@@ -417,6 +423,7 @@ Use first <Skill id="40183"/> precasted for instant <Condition name="Vulnerabili
 
 <ConditionalComponent condition="pug">
 <Boss name="skorvald" video="RoixkWVPAaU" timestamp="" videoCreator="Elda [dT]" foodId="41569" utilityId="9443" heal="arcanebrilliance" utility1="primordialstance" utility2="glyphofstorms" utility3="unravel" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase, if playing <Skill id="5539"/> spam it during <Effect name="Exposed"/> window.
 </Boss>
 
@@ -491,12 +498,14 @@ Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the
 
 <ConditionalComponent condition="static">
 <Boss name="skorvald" video="DaKI7Ccr_Ss" videoCreator="Tym [dT]" foodId="91805" utilityId="9443" heal="arcanebrilliance" utility1="unravel" utility2="glyphofstorms" utility3="primordialstance" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 -   Make sure to drop your <Skill id="5516"/> on the 4th platform ASAP so that your <Specialization name="Soulbeast"/> can pick it up before taking the Portal
 
 -   In **VERY** fast groups it's not that bad to use <Skill id="5539"/> instead of <Skill id="40183"/>. Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase, if playing <Skill id="5539"/> spam it during <Effect name="Exposed"/> window.
 
 
 <Warning>
+
 One of the most important things in this fight is to keep up <Boon name="Might"/> and boons at the four *Elite Flux Anomalies*. To achieve this you need to be fast enough with your damage, hit your blasts correctly and not get hit by the shockwaves and knockbacks.
 </Warning>
 </Boss>
@@ -583,6 +592,7 @@ One of the most important things in this fight is to keep up <Boon name="Might"/
 
 <ConditionalComponent condition="pug">
 <Boss name="artsariiv" video="FErf2jfVRRM" timestamp="" videoCreator="Elda [dT]" foodId="41569" utilityId="9443" heal="glyphofelementalharmony" utility1="primordialstance" utility2="glyphofstorms" utility3="arcaneblast" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 -   Play <Trait name="ragingstorm"/> over <Trait name="stormsoul"/>!
 
 -   Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase.
@@ -647,6 +657,7 @@ One of the most important things in this fight is to keep up <Boon name="Might"/
 
 <ConditionalComponent condition="static">
 <Boss name="Artsariiv" video="DaKI7Ccr_Ss" timestamp="109" videoCreator="Tym [dT]" foodId="91805" utilityId="9443" heal="arcanebrilliance" utility1="primordialstance" utility2="glyphofstorms" utility3="arcaneblast" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 -   Play <Trait name="ragingstorm"/> over <Trait name="stormsoul"/>!
 
 -   Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase.
@@ -743,6 +754,7 @@ It's not that easy precast and opener, it's recommended to check any PoV before 
 
 <ConditionalComponent condition="pug">
 <Boss name="arkk" video="9pMxn4HtUyI" timestamp="" videoCreator="Elda [dT]" foodId="41569" utilityId="50082" heal="glyphofelementalharmony" utility1="primordialstance" utility2="glyphofstorms" utility3="arcaneblast" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 -   Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase and mini bosses.
 
 -   Spam your <Skill id="5539"/> during <Effect name="Exposed"/> window. Use one blast at start of phase 1 and in phase 3 when <Skill name="onewolfpack"/> is up.
@@ -858,6 +870,7 @@ It's not that easy precast and opener, it's recommended to check any PoV before 
 
 <ConditionalComponent condition="static">
 <Boss name="Arkk" video="DaKI7Ccr_Ss" timestamp="212" videoCreator="Tym [dT]" foodId="91805" utilityId="50082" heal="glyphofelementalharmony" utility1="primordialstance" utility2="glyphofstorms" utility3="arcaneblast" elite="conjurefierygreatsword" weapon1MainAffix="Berserker" weapon1MainType="sword" weapon1MainSigil1="impact" weapon1MainInfusion1Id="37131" weapon1OffAffix="berserker" weapon1OffType="dagger" weapon1OffSigil="force" weapon1OffInfusionId="37131">
+
 -   Precast <Skill id="40183"/> for instant <Condition name="Vulnerability"/> at the start of each phase and mini bosses.
 
 -   Spam your <Skill id="5539"/> during <Effect name="Exposed"/> window. Use one blast at start of phase 1 and in phase 3 when <Skill name="onewolfpack"/> is up.

--- a/cm-guides/guardian/power-firebrand/index.md
+++ b/cm-guides/guardian/power-firebrand/index.md
@@ -9,6 +9,7 @@ disableBosses: ['LightAi', 'DarkAi']
 <ConditionalComponent condition="pug">
 <Boss name="mama" video="odHRC78RDGU" videoCreator="SLifeR [dT]" foodId="43360" utilityId="50082" healId="41714" utility1Id="40915" utility2Id="9125" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
 <Warning>
+
 This fight gets very messy if the adds are not immediately CCed. Especially at this fight it is recommended to grab additional CC skills to make up for the lack of CC of your team mates.
 </Warning>
 </Boss>
@@ -96,6 +97,7 @@ This fight gets very messy if the adds are not immediately CCed. Especially at t
 
 <ConditionalComponent condition="pug">
 <Boss name="siax" video="7B1LNFpHYdc" videoCreator="SLifeR [dT]" foodId="43360" utilityId="50082" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="Serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Serpent slaying" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   The rotation for scepter/sword is the same for every specialization. **Sword tends to perform much better on both <Specialization name="Firebrand"/> and <Specialization name="Dragonhunter"/>**!
 
 </Boss>
@@ -182,6 +184,7 @@ NOTE - you should help both <Specialization name="Weaver"/> and <Specialization 
 
 <ConditionalComponent condition="static">
 <Boss name="siax" video="" videoCreator="" foodId="43360" utilityId="50082" healId="21664" utility1Id="30364" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="Serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Serpentslaying" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   The rotation for scepter/sword is the same for every specialization. **Sword tends to perform much better on both <Specialization name="Firebrand"/> and <Specialization name="Dragonhunter"/>**!
 
 - When playing <Specialization text="Core Guardian" name="Guardian"/> you will have a free utility slot. Take <Skill name="judges intervention"/> to get back to siax fast after the seoncd split phase.
@@ -191,11 +194,13 @@ NOTE - you should help both <Specialization name="Weaver"/> and <Specialization 
 </Boss>
 
 <Warning>
+
 These builds only work if you can kill Siax in under 40 seconds. If there is any doubt about the kill time, go with the PuG version.
 </Warning>
 
 <Tabs>
 <Tab specialization="Dragonhunter" title="Dragonhunter">
+
 ### **Phase 1**
 
 - <Skill name="symbolofblades"/>
@@ -379,6 +384,7 @@ Keep in mind that if your group is not fast enough, you need to use <Skill name=
 
 <ConditionalComponent condition="static">
 <Boss name="ensolyss" video="vSTN-MxFcFg" videoCreator="Ganny [dT]" foodId="91805" utilityId="50082" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="serpentslaying" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 If your group can phase Ensolyss in under 16 seconds you can swap to <Specialization name="Dragonhunter"/> or <Specialization text="Core Guardian" name="Guardian"/>. If you do this you (and every class that doesn't generate self <Boon name="Quickness"/>) will need to replace <Item id="24868"/> with <Item id="24865"/> and your <Specialization name="Soulbeast"/> will need to take <Skill name="Moa Stance"/>!
 </Boss>
 </ConditionalComponent>
@@ -457,12 +463,14 @@ Notes:
 
 <ConditionalComponent condition="pug">
 <Boss name="Skorvald" video="4E3fM2vqwrU" videoCreator="SLifeR [dT]" foodId="91805" utilityId="9443" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Scepter" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 Skill usage on Skorvald depends on whether your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, <Skill name="Legendary Assassin Stance"/> or <Skill name="Legendary Demon Stance"/>. If your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, you can take <Skill name="sword of justice"/>. In all other cases take <Skill name="standyourground"/>.
 </Boss>
 </ConditionalComponent>
 
 <ConditionalComponent condition="static">
 <Boss name="Skorvald" video="PrWib9gJ6sA" videoCreator="Ganny [dT]" foodId="91805" utilityId="73191" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Scepter" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Focus" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 Skill usage on Skorvald depends on whether your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, <Skill name="Legendary Assassin Stance"/> or <Skill name="Legendary Demon Stance"/>. If your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, you can take <Skill name="sword of justice"/>. In all other cases take <Skill name="standyourground"/>.
 </Boss>
 </ConditionalComponent>
@@ -539,6 +547,7 @@ Notes:
 <Boss name="Artsariiv" video="fHP_i0ti9PQ" videoCreator="SLifeR [dT]" foodId="91805" utilityId="9443" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
 <Grid>
 <GridItem xs="12" sm="9">
+
 Rotation on Artsariiv depends on whether your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, <Skill name="Legendary Assassin Stance"/> or <Skill name="Legendary Demon Stance"/>. If your <Specialization name="Renegade"/>  runs <Skill name="Legendary Dwarf Stance"/>, you can take <Skill name="sword of justice"/>. In all other cases take <Skill name="standyourground"/>.
 </GridItem>
 
@@ -614,6 +623,7 @@ Stay in the middle
 
 <ConditionalComponent condition="static">
 <Boss name="Artsariiv" video="PrWib9gJ6sA" videoCreator="Ganny [dT]" timestamp="100" foodId="91805" utilityId="73191" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 Rotation on Artsariiv depends on whether your <Specialization name="Renegade"/> runs <Skill name="Legendary Dwarf Stance"/>, <Skill name="Legendary Assassin Stance"/> or <Skill name="Legendary Demon Stance"/>. If your <Specialization name="Renegade"/>  runs <Skill name="Legendary Dwarf Stance"/>, you can take <Skill name="sword of justice"/>. In all other cases take <Skill name="standyourground"/>.
 </Boss>
 
@@ -655,6 +665,7 @@ Rotation on Artsariiv depends on whether your <Specialization name="Renegade"/> 
 
 <ConditionalComponent condition="pug">
 <Boss name="Arkk" video="ZeqPBPfK7Ow" videoCreator="SLifeR [dT]" foodId="91805" utilityId="50082" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   Play scepter on this encounter
 
 - Place markers for the blooms
@@ -664,6 +675,7 @@ Rotation on Artsariiv depends on whether your <Specialization name="Renegade"/> 
 
 <ConditionalComponent condition="static">
 <Boss name="Arkk" video="BzokxHx0ufM" timestamp="135" videoCreator="Ganny [dT]" foodId="91805" utilityId="50082" healId="41714" utility1Id="40915" utility2Id="9168" utility3Id="9093" eliteId="29965" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Focus" weapon2OffSigil="Force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   Play scepter on this encounter
 
 - Place markers for the blooms

--- a/cm-guides/necromancer/power-reaper/index.md
+++ b/cm-guides/necromancer/power-reaper/index.md
@@ -138,6 +138,7 @@ If not under 50% health:
 
 <Boss name="siax" video="" videoCreator="" foodId="43360" utilityId="50082" heal="signetofvampirism" utility1="wellofsuffering" utility2="wellofdarkness" utility3="signetofspite" elite="lichform" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="warhorn" weapon2OffSigil="serpentslaying" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="axe" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
 <Warning>
+
 Remember to equip <Item name="serpentslaying"/> + <Item name="impact"/> for this encounter!
 </Warning>
 </Boss>
@@ -152,7 +153,7 @@ Remember to equip <Item name="serpentslaying"/> + <Item name="impact"/> for this
 
 4.  Take _Mistlock Singularity_
 
-5.  Cast <Skill name="Lich Form"/> 4 at the orb before the encounter starts\_
+5.  Cast <Skill name="Lich Form"/> 4 at the orb before the encounter starts
 
 ### **Phase 1**
 
@@ -228,10 +229,12 @@ Remember to equip <Item name="serpentslaying"/> + <Item name="impact"/> for this
 
 <Boss name="ensolyss" video="" videoCreator="" foodId="91805" utilityId="50082" heal="signetofvampirism" utility1="wellofsuffering" utility2="wellofdarkness" utility3="signetofspite" elite="lichform" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="warhorn" weapon2OffSigil="serpentslaying" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="axe" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
 <Warning>
+
 Remember to equip <Item name="serpentslaying"/> + <Item name="impact"/> for this encounter!
 </Warning>
 
 <Warning>
+
 The exploding adds after Ensolyss’ slam attack fully restore your life force, so auto attack in shroud, dodge the explosions at the very last moment and leave shroud mid dodge!
 </Warning>
 </Boss>
@@ -347,6 +350,7 @@ If you run <Skill name="Summon Flesh Golem"/> start on greatsword and use the go
 ---
 
 <Boss name="skorvald" video="" videoCreator="" foodId="91805" utilityId="9443" heal="signetofvampirism" utility1="wellofsuffering" utility2="wellofdarkness" utility3="signetofspite" elite="lichform" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="warhorn" weapon2OffSigil="force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="axe" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   Skorvald has one of the biggest CC bars in CMs (2200). Make sure to use your CC skills!
 
 </Boss>
@@ -604,6 +608,7 @@ If you run <Skill name="Summon Flesh Golem"/> start on greatsword and use the go
 ---
 
 <Boss name="arkk" video="" videoCreator="" foodId="91805" utilityId="50082" heal="signetofvampirism" utility1="wellofsuffering" utility2="wellofdarkness" utility3="signetofspite" elite="lichform" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="warhorn" weapon2OffSigil="force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="axe" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   Place markers for the blooms
 
 </Boss>
@@ -760,7 +765,7 @@ If you run <Skill name="Summon Flesh Golem"/> start on greatsword and use the go
 
 1.  If you have <Skill name="Lich Form"/> off cooldown, use <Skill name="Lich Form"/> 4 after you have pushed your solar bloom into the pillar
 
-2.  Before _Skorvald_\_ becomes vulnerable:
+2.  Before _Skorvald_ becomes vulnerable:
 
     1.  <Skill name="Locust Swarm"/> (Warhorn 5)
 

--- a/cm-guides/ranger/power-soulbeast/index.md
+++ b/cm-guides/ranger/power-soulbeast/index.md
@@ -9,6 +9,7 @@ disableBosses: ['LightAi', 'DarkAi']
 <ConditionalComponent condition="pug">
 <Boss name="mama" video="" videoCreator="" foodId="43360" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12491" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
 <Warning>
+
 This fight gets very messy if the adds are not immediately CCed. Especially at this fight it is recommended to grab extra CC skills to make up for the lack of CC of your team mates.
 </Warning>
 
@@ -19,10 +20,12 @@ This fight gets very messy if the adds are not immediately CCed. Especially at t
 </Boss>
 
 <Warning>
+
 The timing of <Skill name="One Wolf Pack"/> later on in the fight will depend on your groups DPS and when you first cast it. If it is off cooldown at the start of phase 3 use it then. If not use it after you have casted <Skill name="Barrage"/> on P4.
 </Warning>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up and try not to get stuck auto attacking on Longbow.
 </Warning>
 
@@ -114,6 +117,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="static">
 <Boss name="mama" video="HsGMLaDKzrA" videoCreator="Stellan [dT]" foodId="43360" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12491" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2143"/>.
@@ -126,6 +130,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <Tabs>
 <Tab title="Standard Rotation">
+
 ### **Precast**
 
 - Make sure you have <Trait name="Leader of the pack"/> while precasting!
@@ -220,6 +225,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <Tab title="Delayed Rotation">
 <Warning>
+
 This rotation is designed to be used when playing double Soulbeast comps, it bursts into phases two and four covering the damage that a Soulbeast doing the standard rotation loses and covers the CC that a Weaver would normally do. You should also swap <Skill name="Frost Spirit"/> for <Skill name="Frost Trap"/>. To see a PoV of this in action check the [Videos page](/videos).
 </Warning>
 
@@ -297,6 +303,7 @@ This rotation is designed to be used when playing double Soulbeast comps, it bur
 
 <ConditionalComponent condition="pug">
 <Boss name="siax" foodId="43360" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Greatsword" weapon1MainSigil1="force" weapon1MainSigil2="Serpentslaying" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Serpentslaying" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2128"/>, <Trait name="Two handed training"/>.
@@ -308,14 +315,17 @@ This rotation is designed to be used when playing double Soulbeast comps, it bur
 </Boss>
 
 <Warning>
+
 The timing of <Skill name="One Wolf Pack"/> in this fight will depend on your group. If your group has low DPS and/or is running into the fight use <Skill name="One Wolf Pack"/> just before the CC bar appears on P1 and again at the start of P3. If your group is portalling into the fight and has reasonable DPS cast <Skill name="One Wolf Pack"/> as late as you can in the precast, then save it for the start of P2.
 </Warning>
 
 <Warning>
+
 If your P1 is slow you may have time to swap to Greatsword for the first split phase. When you go back to Siax use <Skill id="46629"/> -> <Skill name="Path of Scars"/> -> <Skill name="Whirling Defense"/> to burst into <Effect name="Exposed"/>.
 </Warning>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up.
 </Warning>
 
@@ -383,6 +393,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="static">
 <Boss name="siax" video="6JGgL1pGqmM" videoCreator="Jetrell [dT]" foodId="43360" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="Impact" weapon1MainSigil2="Serpentslaying" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Serpentslaying" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle if you CC, <Skill id="44617" disableText/> Red Moa if you aren't breaking.
 
 - Take <Trait id="2128"/>.
@@ -397,6 +408,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <Tabs>
 <Tab title="Standard Rotation">
+
 ### **Precast**
 
 - Precast <Skill name="Frost Trap"/> and a <Item id="78978"/> entrance on the boss orb before the fight starts.
@@ -467,6 +479,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <Tab title="Quickdraw Rotation">
 <Warning>
+
 When you play this rotation you will want to replace the Marksmanship traitline with the following traits on the Skirmishing traitline; <Trait name="Sharpened Edges"/>, <Trait name="Hidden Barbs"/> and <Trait name="Quickdraw"/>. <Trait name="Spotter"/> is optional and should be run if your group needs the precision to Crit cap, and <Trait name="Trappers Expertise"/> can be run if it will allow you to fit a <Skill name="Frost Trap"/> in on Phase 2 (Will only be worth taking if your group is slow!). To see a PoV of this in action check the [Videos page](/videos).<Traits traits1Id="30" traits1="Skirmishing" traits1SelectedIds="1069,1846,1064" unembossed/>There are Two ways to handle the splits with this strat. With a double <Specialization name="Dragonhunter"/> comp you can solo your first add with the help of precasted traps and duo the second add with the other <Specialization name="Soulbeast"/>. If you run other comps you should duo both adds.
 </Warning>
 
@@ -538,6 +551,7 @@ When you play this rotation you will want to replace the Marksmanship traitline 
 
 <ConditionalComponent condition="pug">
 <Boss name="ensolyss" foodId="91805" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12491" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="serpentslaying" weapon1MainSigil2="Force" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Serpentslaying" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2128"/>.
@@ -547,10 +561,12 @@ When you play this rotation you will want to replace the Marksmanship traitline 
 </Boss>
 
 <Warning>
+
 The following guide is assuming your group doesn't instabreak the first CC bar. If you are going to instabreak you should refer to the static opener then follow the rest of the rotation from this guide.
 </Warning>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up and try not to get stuck auto attacking on Longbow.
 </Warning>
 
@@ -620,6 +636,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="static">
 <Boss name="ensolyss" video="x1hLiHyN3t8" videoCreator="Stellan [dT]" foodId="91805" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="Serpentslaying" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Serpentslaying" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2128"/> and <Trait name="Clarion Bond"/>.
@@ -700,6 +717,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="pug">
 <Boss name="skorvald" video="o7R-tnLH4ws" videoCreator="Elu" foodId="91805" utilityId="9443" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2128"/>.
@@ -713,10 +731,12 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 </Boss>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up and try not to get stuck auto attacking on Longbow.
 </Warning>
 
 <Warning>
+
 Spirit Management:
 
 - If you run with a healer you can summon it on the platform and you can forget about it as it will probably stay alive the whole fight (Obviously if it dies resummon it!).
@@ -787,6 +807,7 @@ Spirit Management:
 
 <ConditionalComponent condition="static">
 <Boss name="skorvald" video="CTfw_n75sR4" videoCreator="BlackHawk [dT]" foodId="91805" utilityId="9443" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Impact" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait id="2128"/>.
@@ -804,6 +825,7 @@ Spirit Management:
 <Tabs>
 <Tab title="4 Way Split">
 <Warning>
+
 Spirit Management:
 
 - You should spwan your spirit at the entrance to the fractal and let it tick down to around 70% before starting to precast. This means the spirit will die after the first phase and you can resummon it before phase 2, where it will survive for the rest of the fight.
@@ -874,6 +896,7 @@ Spirit Management:
 
 <Tab title="Portal Strat">
 <Warning>
+
 Spirit Management:
 
 - This depends on how your <Specialization name="Renegade"/> plays, if they precast <Skill id="45686"/> before Skorvald spawns then you can summon your <Skill name="Frostspirit"/> down on the boss platform after the precast and the Kalla heal skill will sustain it until the second phase. In this scenario you don't teleport it at all you just leave it behind.
@@ -932,6 +955,7 @@ Spirit Management:
 
 <ConditionalComponent condition="pug">
 <Boss name="artsariiv" video="o7R-tnLH4ws" timestamp="112" videoCreator="Elu" foodId="91805" utilityId="9443" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12491" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon1MainInfusion2Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="43636" disableText/> Rock Gazelle.
 
 - Take <Trait name="Oppressive Superiority"/>.
@@ -945,18 +969,22 @@ Spirit Management:
 </Boss>
 
 <Warning>
+
 If you group is going to skip the first anomaly, follow the rotation for side strat in the static section.
 </Warning>
 
 <Warning>
+
 This guide assumes you are going to let your group kill the 2nd and 3rd anomalies or skip them completely. If you get the bomb don't panic. Attempt to get the reflect and then if you have time special action key to the dome or /gg! If your group can't kill the anomaly without you you can still attempt to reflect. When you get to the side use <Skill name="Point Blank Shot"/>, quickly weapon swap and <Skill name="Path of Scars"/> -> <Skill name="Whirling Defense"/>.
 </Warning>
 
 <Warning>
+
 If your group has fast or organised CC on the split phases, your <Skill name="Whirling Defense"/> probably won't be off cooldown in the middle. If this is the case use <Skill name="pathofscars"/> and swap to Longbow and proc <Item id="84505"/> with <Skill name="Point Blank Shot"/>. Then use <Skill name="Rapid Fire"/> and your pet skills.
 </Warning>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up and try not to get stuck auto attacking on Longbow.
 </Warning>
 
@@ -1016,6 +1044,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="static">
 <Boss name="artsariiv" video="rYhC4Ne7JCU" timestamp="" videoCreator="BlackHawk [dT]" foodId="91805" utilityId="9443" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon2MainType="Axe" weapon2MainAffix="Berserker" weapon2MainSigil1="Force" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131">
+
 -   Pet: <Skill id="44617" disableText/> Red Moa for DPS, <Skill id="43636" disableText/> Rock Gazelle for CC.
 
 - Take <Trait id="2128"/>.
@@ -1033,6 +1062,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 <Tabs>
 <Tab title="Mid Strat">
 <Warning>
+
 If you are going to triple mid burn you may want to run the replace Marksmanship with the following traits which will allow you to use <Skill name="Frost Trap"/> each phase.<Traits traits1="Skirmishing" traits1Id="30" traits1SelectedIds="1075,1846,1888" unembossed/>Since there is no <Effect name="Exposed"/> in mid strat, it is worth swapping <Item id="24868"/> for <Item id="24597"/> on your off-hand Axe.
 </Warning>
 
@@ -1095,6 +1125,7 @@ If you are going to triple mid burn you may want to run the replace Marksmanship
 </Tab>
 
 <Tab title="Side Strat">
+
 ### **Precast**
 
 - Remember to share <Skill name="Moastance"/> and blast <Boon name="Might"/> with <Skill name="Callofthewild"/>.
@@ -1163,6 +1194,7 @@ If you are going to triple mid burn you may want to run the replace Marksmanship
 
 <ConditionalComponent condition="pug">
 <Boss name="arkk" video="o7R-tnLH4ws" timestamp="228" videoCreator="Elu" foodId="91805" utilityId="50082" healId="31914" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="Impact" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Force" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="44617" disableText/> Red Moa.
 
 - Take <Trait id="2128"/>.
@@ -1182,6 +1214,7 @@ If you are going to triple mid burn you may want to run the replace Marksmanship
 </Boss>
 
 <Warning>
+
 Your rotation will depend on your groups DPS and ability to CC! In general make sure you have as many damage modifiers up as you can when you do your burst and try to time it with the <Effect name="Exposed"/> effect. Outside of your burst use skills with shorter cooldowns while you wait for your cooldowns to line up and try not to get stuck auto attacking on Longbow.
 </Warning>
 
@@ -1311,6 +1344,7 @@ Your rotation will depend on your groups DPS and ability to CC! In general make 
 
 <ConditionalComponent condition="static">
 <Boss name="arkk" video="pcBwuDwX8zo" timestamp="187" videoCreator="Stellan [dT]" foodId="91805" utilityId="50082" healId="12483" utility1Id="12633" utility2Id="12497" utility3Id="12492" eliteId="45717" weapon1MainAffix="Berserker" weapon1MainType="Longbow" weapon1MainSigil1="force" weapon1MainSigil2="Severance" weapon1MainInfusion1Id="37131" weapon2OffAffix="Berserker" weapon2OffType="Axe" weapon2OffSigil="force" weapon2OffInfusionId="37131" weapon2MainAffix="Berserker" weapon2MainType="Sword" weapon2MainSigil1="Impact" weapon2MainInfusion1Id="37131">
+
 -   Pet: <Skill id="44617" disableText/> Red Moa.
 
 - Take <Trait id="2128"/>.

--- a/fractals/aetherblade/index.md
+++ b/fractals/aetherblade/index.md
@@ -31,14 +31,17 @@ sigils:
 
 <Grid>
 <GridItem sm="8">
+
 You can stack <Effect name="Stealth"/> before entering the water to cheat the exploding mines. Clear the group of *Elite Aetherblades* to open the door.
 
 <Tabs>
 <Tab specialization="thief">
+
 Use the smoke field from <Skill id="13113"/> or <Skill name="Smoke Screen" profession="thief"/> or simply cast <Skill id="13117"/> to stack <Effect name="Stealth"/>.
 </Tab>
 
 <Tab specialization="ranger">
+
 Use <Skill id="31568"/> from your Smokescale pet to stack <Effect name="Stealth"/> at the beginning.
 </Tab>
 </Tabs>
@@ -57,6 +60,7 @@ Use <Skill id="31568"/> from your Smokescale pet to stack <Effect name="Stealth"
 
 <Grid>
 <GridItem sm="8">
+
 After the door opens, you enter a large area with two deathly laser puzzles.
 
 The first one consists of a _moving laser square pattern_ and can be disabled by activating four consoles inside a small room at the end of it. Pressing a console applies <Condition name="Immobile"/> to you.
@@ -120,14 +124,17 @@ You can solo both the first and second room if you are fast enough. Use <Skill i
 <GridItem>
 <Tabs>
 <Tab specialization="Revenant">
+
 You can <Skill name="Call to Anguish"/> most mobs to group them.
 </Tab>
 
 <Tab specialization="elementalist">
+
 Stay in <Skill id="5492"/> after the last trash group for <Boon name="Might"/> stacking at Frizz.
 </Tab>
 
 <Tab specialization="Guardian">
+
 You can use <Skill name="Binding Blade"/> to group the mobs.
 </Tab>
 </Tabs>
@@ -167,20 +174,24 @@ If a golem walks through a laser, he powers up and blocks all attacks for a shor
 
 <Tabs>
 <Tab specialization="revenant">
+
 Use <Skill name="Inspiring Reinforcement"/> in <Skill name="Legendary Dwarf Stance" disableText/> for <Boon name="Stability"/> against the *Lasers* and *Small Lasers*.
 </Tab>
 
 <Tab specialization="Warrior">
+
 Drop your banners in the very center of the arena.Using <Skill name="whirlwind attack"/> against the wall is very effective.
 </Tab>
 </Tabs>
 
 <Tabs>
 <Tab specialization="ranger">
+
 Run an offhand axe and use <Skill id="12638"/> to pull golems closer.
 </Tab>
 
 <Tab specialization="elementalist">
+
 Use <Skill id="5697"/> against the golems next to a wall or box.
 </Tab>
 </Tabs>

--- a/fractals/chaos-isles/index.md
+++ b/fractals/chaos-isles/index.md
@@ -40,6 +40,7 @@ sigils:
 
 <Grid>
 <GridItem sm="8">
+
 ## Start: You think this is Cliffside
 
 Kill the four _Veteran Chanters_ at the beginning to open the gate on the right-hand side. The fastest person can rush ahead and move to the next checkpoint at the _Chaos Anomaly_, everyone else can `/gg` and resurrect at the checkpoint there.
@@ -62,6 +63,7 @@ Kill the four _Veteran Chanters_ at the beginning to open the gate on the right-
 
 <Grid>
 <GridItem>
+
 Stack <Boon name="Might"/> before the four *K1T-A golems* and kill them to spawn the Chaos Anomaly. Every 25% health, she will become immune to damage and you have to kill K1T-A golems again to continue. With every phase there will be one less K1T-A golem but the remaining grow in strength, the final single golem at 25% health has about 1.5m health.
 
 Pay attention to the <Control name="Knockback"/> zones from the small JT-12 golems and look out for _Flux Bombs_, the debuff can be hard to notice on the mosaic ground.
@@ -70,14 +72,17 @@ Pay attention to the <Control name="Knockback"/> zones from the small JT-12 gole
 <GridItem>
 <Tabs>
 <Tab specialization="Revenant">
+
 It is favorable to run <Skill name="Legendary Centaur Stance"/> for projectile absorption with <Skill name="Protective Solace"/> and condition cleanse with <Skill name=" Purifying Essence"/>. Recommended to use the Salvation / Invocation / Renegade variant for more energy for the whole fight.
 </Tab>
 
 <Tab specialization="Guardian">
+
 You can use <Skill name="Binding Blade"/> to group the little cats at the start and then every phase of Chaos Anomaly, the position you need to place yourself for perfect pull can vary based on what cat you killed last, there are variations you can't pull all of them, only 2.
 </Tab>
 
 <Tab specialization="ranger">
+
 Run an offhand axe and use <Skill id="12638"/> to pull golems closer.
 </Tab>
 </Tabs>
@@ -96,6 +101,7 @@ Run an offhand axe and use <Skill id="12638"/> to pull golems closer.
 </GridItem>
 
 <GridItem sm="7">
+
 ## Blizzard path (Forest)
 
 You will need to enlighten four _bonfires_ on the path to progress to the end boss, **the _Enlighten_ charges have unlimited use so this can be soloed** but if you want to be safe simply wait for everyone.
@@ -108,6 +114,7 @@ You can stack <Effect name="Stealth"/> to skip the mobs though it usually is not
 
 <Grid>
 <GridItem sm="8">
+
 ## Legendary Brazen Gladiator
 
 The end boss is only vulnerable when his protective bubble is removed by pulling him into the moving purple areas.\

--- a/fractals/deepstone/index.md
+++ b/fractals/deepstone/index.md
@@ -18,10 +18,12 @@ sigils:
 
 <Grid>
 <GridItem sm="12">
+
 ## Always start Left path with the Deepstone Sentinel (Air Elemental)
 </GridItem>
 
 <GridItem sm="5">
+
 Before the *Deepstone Sentinel*, there is a Tetris-like obstacle you have to pass. You have to avoid the green tiles because it damages you. You can dodge and block the green tiles between the safe non glowing tiles, proceed to the end. **This can be skipped by <Specialization name="Berserker"/>, <Specialization name="Soulbeast"/>, <Specialization name="Firebrand"/>, like in the video down below.**
 
 After two players passed, they stand on the cyan glowing runes to stop the Tetris trap so others can pass. <Specialization name="Elementalist"/> can use <Skill name="Lightning flash"/> to activate both button, a little higher ping helps with this immensely.
@@ -58,6 +60,7 @@ After two players passed, they stand on the cyan glowing runes to stop the Tetri
 </GridItem>
 
 <GridItem sm="7">
+
 After prestacking <Boon name="Might"/> at the Mistlock Singularity move in and the *Deepstone Sentinel* spawns. The only dangerous attack it has is an AoE tornado (called Wind Sprites) that you have to dodge at every 20%. It is a well telegraphed attack so you only have to make sure you are not standing in it 1 second later. If it manages to catch you, others have to use CC to break you out of it before it floats you to the depths and kill you. There is a possibility you get caught even if you are not standing in it, use Skill 1 to break out of it (If you get caught in it and you stood in the AoE Skill 1 does nothing else than pinging on minimap, so keep that in mind).
 
 The other three attacks are a mini tornado that applies <Condition name="Chilled"/> and the AoEs that <Control name="Daze"/>, the third attack is a projectile it shoots in-between which can be reflected / absorbed. After killing the _Deepstone Sentinel_ the crystal energy orb spawns, take it and interact with the Vibrant Crystal in the middle.
@@ -75,10 +78,12 @@ Use <Skill name="Inspiring Reinforcement"/> in <Skill name="Legendary Dwarf Stan
 </GridItem>
 
 <GridItem sm="12">
+
 ## The Brood Queen (Spider)
 </GridItem>
 
 <GridItem sm="8">
+
 Commonly the Brood Queen is picked second from the two paths. On your way to the *Brood Queen* you will see spider nests, destroy them. You have to stand on two cyan glowing runes in the middle of the bridge to unblock the path to the *Brood Queen*. There are telegraphed wind currents that are unblockable, if you happen to get hit by one it puts you back at the start of the bridge. Kill the two elite *Broodmother Spider* to spawn the *Brood Queen*. This boss does not hit hard and most attack are telegraphed. After killing her the crystal energy ball comes down. Take it and you get spawned back in the middle. Take the ball to the Vibrant crystal in the end of the hall.
 </GridItem>
 
@@ -109,6 +114,7 @@ Use <Skill name="Legendary Demon Stance"/> to remove <Boon name="Protection"/> w
 
 <Grid>
 <GridItem sm="6">
+
 ### Shadow Minotaur, Middle Room
 
 After merging the second orb with the Vibrant Crystal, you get a Special Action Key skill called <SpecialActionKey name="lightofdeldrimor"/>. This skill is used to reveal hidden chest in the dungeon as well as making the mobs 10% more vulnerable and it also serves as revealing the Shadow Minotaur in the central chamber. After killing the Shadow Minotaur and the Imps the door in the middle chamber opens. Go in and move on to the next obstacle, the Maze.
@@ -123,6 +129,7 @@ After merging the second orb with the Vibrant Crystal, you get a Special Action 
 <GridItem sm="6">
 <Tabs>
 <Tab specialization="Elementalist">
+
 Use <Skill name="Lightning Flash"/>, <Skill name="Ride the Lightning"/> or <Skill id="5516"/> to move faster to to the maze and thus activate it faster.
 </Tab>
 </Tabs>
@@ -131,6 +138,7 @@ Use <Skill name="Lightning Flash"/>, <Skill name="Ride the Lightning"/> or <Skil
 <GridItem sm="6">
 <Tabs>
 <Tab specialization="Renegade">
+
 **<Specialization name="Renegade"/> can give <Boon name="Alacrity"/> to reduce the cooldown of <SpecialActionKey name="lightofdeldrimor"/>.** Especially helpful at the Maze part.
 </Tab>
 </Tabs>
@@ -143,6 +151,7 @@ Use <Skill name="Lightning Flash"/>, <Skill name="Ride the Lightning"/> or <Skil
 </GridItem>
 
 <GridItem sm="6">
+
 ### The Maze
 
 Here you have to use the <SpecialActionKey name="lightofdeldrimor"/> to reveal the hidden tiles of the maze. Move to the right and the first orb of light is revealed for you. From there you proceed on to the next orb of light to your left or the bottom left on the minimap. After revealing all four orbs the maze's tiles reveal themselves and you can move on to the "elevator".
@@ -153,20 +162,24 @@ Here you have to use the <SpecialActionKey name="lightofdeldrimor"/> to reveal t
 </GridItem>
 
 <GridItem sm="12">
+
 ### Elevator (Sinking platform)
 </GridItem>
 
 <GridItem sm="7">
+
 After standing on the rune in the middle of the platform it proceeds to go downward. If you didn't step in in time, no worries, there is a cyan glowing rune that teleports you down. As the platform goes down, it stops in the middle and mobs spawn. It's two waves of mobs with first being Veteran Imps only, then an Elite Minotaur and Veteran Imps. **Use the <SpecialActionKey name="lightofdeldrimor"/> to make them vulnerable** and after killing them the platform moves again. You can jump down but it can happen that you die if you jump from too high. It is more safe to wait until it is fully down.
 </GridItem>
 
 <GridItem sm="5">
 <Tabs>
 <Tab specialization="Guardian">
+
 Use <Skill name="Binding Blade"/> (Greatsword 5) to group the mobs.
 </Tab>
 
 <Tab specialization="Elementalist">
+
 Use <Skill name="Lightning Flash"/> and <Skill name="Ride the Lightning"/> to get to to the elevator quicker and thus activate it faster.
 </Tab>
 </Tabs>
@@ -179,6 +192,7 @@ Use <Skill name="Lightning Flash"/> and <Skill name="Ride the Lightning"/> to ge
 
 <Grid>
 <GridItem sm="8">
+
 Before fight <Label>Pre-stack</Label>
 
 Prestack <Boon name="Might"/> and proceed to the boss. The boss has several mechanics. The first you will notice is he is teleporting to a random location of the arena at every 10%. The tiles of the arena can be revealed with the <SpecialActionKey name="lightofdeldrimor"/> skill. Spam this skill all the time and you won't have a problem with disappearing tiles.

--- a/fractals/molten-furnace/index.md
+++ b/fractals/molten-furnace/index.md
@@ -18,6 +18,7 @@ sigils:
 
 <Grid>
 <GridItem sm="6">
+
 ## Starting area and the tunnel
 
 Go to Rox and Braham, wait for the mobs to spawn, kill them. After killing them, proceed into the tunnel, there are 5 caves in the tunnel, each having a group of mob in it, after killing the mobs, destroy the _Boulder_ that becomes damageable (a red gear indicates it's place). After killing all 5 group of mobs and destroying all 5 _Boulders_ on the red gears you wait for the Drill to make it's way out of the tunnel (which should be already done).
@@ -40,6 +41,7 @@ Go to Rox and Braham, wait for the mobs to spawn, kill them. After killing them,
 </GridItem>
 
 <GridItem sm="6">
+
 ## On your way to the Boss
 
 You exit the tunnel and kill the group of mobs coming to you. Then proceed to the Steam Walls. The first Steam Wall is unpassable, each Steam Wall knocks you back and damage you. After the first, you can pass the following Steam Walls by walking backwards in them (do not walk into them with low HP, that downs or even kills you) or use <Boon name="Stability"/>. Make your way on to the weapon testing arena.
@@ -50,6 +52,7 @@ You exit the tunnel and kill the group of mobs coming to you. Then proceed to th
 
 <Grid>
 <GridItem sm="5">
+
 ## Weapon Testing Arena <Label>Random</Label>
 
 You enter the arena and survive the 3 weapon test. After entering the arena 2 Champions spawn, separate them and kill them. Not separating them results in <Boon name="Resolution"/> being applied. The weapon test types are in random order:
@@ -62,6 +65,7 @@ You enter the arena and survive the 3 weapon test. After entering the arena 2 Ch
 </GridItem>
 
 <GridItem sm="6">
+
 **Fire Tornadoes**
 
 You have to dodge the Fire Tornadoes coming towards you. The Tornadoes apply <Condition name="Burning"/> and knock back. Please note that since the rework, the Fire Tornadoes **go through** the _Thermal Core_. After surviving the test you can damage 25% of the _Thermal Core_.
@@ -72,6 +76,7 @@ You have to avoid, block or reflect the Fire Barrage falling on you, place refle
 </GridItem>
 
 <GridItem sm="6">
+
 **Shockwaves**
 
 You have to dodge, block or jump over the shockwaves coming towards you. The shockwaves apply <Control name="Knockdown"/>. After surviving the test you can damage 25% of the _Thermal Core_.

--- a/fractals/nightmare/index.md
+++ b/fractals/nightmare/index.md
@@ -80,6 +80,7 @@ Fast crowd control and animation knowledge are the keys to this fight.
 
 <Grid>
 <GridItem sm="8">
+
 ## First set of altars <Item id="50082" disableText/><Item id="24658" disableText/>
 
 Swap your weapon set to <Item name="Impact"/> and <Item name="Serpentslaying"/>. You need to cap two altars to continue. Pull the two groups of Krait back to the passage and kill all enemies there. Start capping the altars as soon as possible, but keep in mind that standing inside puts <Effect name="Agony"/> on yourself. Only enemy Krait counteract the capping here, you can ignore the Hallucinations.\
@@ -96,6 +97,7 @@ On a side note, more players do not cap an altar faster. More than one person st
 
 <Tabs>
 <Tab specialization="berserker">
+
 Exchange <Skill name="signetofmight"/> or <Skill name="forgreatjustice"/> for <Skill name="on my mark" profession="Warrior"/> and already swap to your weapon sets with Superior Sigil of Serpent Slaying.
 
 At the first set of altars draw the Elite Nightmare Hypnoss with <Skill name="on my mark" profession="Warrior"/> to the narrow corridor so that the <Specialization name="Firebrand"/> can pull them together with <Skill name="Binding Blade"/> and disable them with <Skill name="Tremor" profession="Warrior"/>. Assist in killing the Elite Nightmare Hypnoss and capturing one of the two altars.
@@ -126,16 +128,19 @@ If the person who pulled your side ported up the other side to fast and the mobs
 </Tab>
 
 <Tab specialization="Firebrand">
+
 Use <Skill name="Binding Blade"/> and <Skill name="tomeofjustice"/> to pull adds.
 
 Use tome of courage skill 4 to give resistance.
 </Tab>
 
 <Tab specialization="berserker">
+
 At the second set of altars, wait for your <Specialization name="Firebrand"/> to pull them together with <Skill name="Binding Blade"/> and disable the Elite Nightmare Hypnoss with <Skill name="Tremor" profession="Warrior"/>. Immediately move close to the altar on the right side and pull the Elite Nightmare Hypnoss occupying the altar to the mid by using <Skill name="on my mark" profession="Warrior"/>. Assist in killing the remaining Elite Nightmare Hypnoss and capture the mid altar respectively.
 </Tab>
 
 <Tab specialization="dragonhunter">
+
 Use <Skill name="Binding Blade"/> and <Skill name="Dragonsmaw"/> excessively to pull as many mobs as possible.
 
 At the second set of altars use your <Skill name="Huntersverdict"/> to pull out the Elite Nightmare Hypnoss occupying the center circle. Make sure, that there are no projectile blocking Skills from enemies present.
@@ -180,6 +185,7 @@ Assign players to each add before the fight starts by setting waypoints. In PuGs
 
 <Grid>
 <GridItem>
+
 Walk through the teleporter and trigger Ensolyss once after defeating Siax to gain the new checkpoint and use `/gg` to reset all cooldowns. Stack <Boon name="Might"/>, <Boon name="Quickness"/> and <Boon name="Alacrity"/> before starting the fight. Good teams will use a <Item id="78978"/> to teleport to the boss. When you start the fight don't stand in the center area of the platform or you will receive a <Control name="Knockback"/>. Right after he looses his <Effect name="Invulnerability"/> there is a CC bar. This bar is only breakable for approximately one second. Time your CC wise.
 
 Nearly all of Ensolyss' attacks do a <Control name="Knockback"/> or <Control name="Pull"/>, learn to dodge or walk out of every attack. The most dangerous one is his shockwave-shatter combo, he smashes down a stunning yellow shockwave (like MAMA below 33% health), spawns hallucinations on each players position and shatters them after two seconds.

--- a/fractals/shattered-observatory/index.md
+++ b/fractals/shattered-observatory/index.md
@@ -51,6 +51,7 @@ sigils:
 
 <Grid>
 <GridItem sm="7">
+
 Skorvald the Shattered is the first boss in the Shattered Observatory fractal. Be sure to take the *Mistlock Singularity* after accepting the Harbringer's challenge, stack <Boon name="Might"/>, <Boon name="Quickness"/> and <Boon name="Alacrity"/> on the platform below and start the encounter by activating the orb in the center of the platform.
 </GridItem>
 
@@ -84,6 +85,7 @@ Skorvald the Shattered is the first boss in the Shattered Observatory fractal. B
 </GridItem>
 
 <GridItem sm="9">
+
 ### Tactic
 
 The key to the fight is fast crowd control, as breaking Skorvald's Defiance bar prevents most of the mechanics. Immediately break it at the start and bring him down to 66% health. Please note, that you cannot _precast_ CC here. Your CC affects Skorvald, as soon as his HP bar appears in the top right corner.
@@ -104,6 +106,7 @@ After about 30 seconds, Skorvald starts a huge laser beam attack (_Beaming Smile
 
 <Grid>
 <GridItem sm="8">
+
 After Skorvald is dead, take the portal to the East and take the left portal in the control center area. You can activate a <Item id="78786"/> to walk during the cutscene and save some time.
 
 You gain a new special action key: <SpecialActionKey name="hypernovalaunch"/>. For the moment, it is a 2100-range teleport with stunbreak that blocks the next attack (1.75s <Boon name="Aegis"/>). Its cooldown refreshes after you bounce a _Globolla Marble_.
@@ -135,6 +138,7 @@ If you have a spare <Item id="78978"/> or <Item id="44642"/>, you can skip direc
 
 <Grid>
 <GridItem sm="8">
+
 The second boss of the fractal is Artsariiv. The encounter gets activated by bouncing a *Globolla Marble* into her, be sure to prepare <Boon name="Might"/> and skills in the northwest beforehand.
 
 Artsariiv summons copies which split into smaller clones upon death, they use martial arts skills, <Control name="Knockdown"/>, shoot shocking projectiles and apply a lot of damaging conditions. Discuss whether you kill all adds (safe tactic) or not.
@@ -153,6 +157,7 @@ Assign a player for the _Globolla Marble_ bouncing (typically the <Specializatio
 
 <Grid>
 <GridItem sm="9">
+
 |                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Beaming Smile**                  | Similar to Skorvald below 50% health, Artsariiv generates three large laser beams and projects a white beam onto players which inflicts high damage, <Condition name="Blinded"/> and <Condition name="fear"/>. Turn away from the source to prevent application.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
@@ -204,6 +209,7 @@ After the fight is over, take the portal in the North and move forward to get to
 
 <Grid>
 <GridItem sm="8">
+
 Arkk is the third and final boss of the fractal. An attentive player may have noticed the <SpecialActionKey name="hypernovalaunch"/> special action key became even stronger now, doing medium damage, a 232 <Control name="Launch"/> and executing a Blast finisher. Thanks to this, other crowd control skills are negligible for this fight.
 
 In contrast to the other enemies in this fractal, Arkk belongs to Scarlet's army and <Item id="50082"/> works against him.
@@ -222,6 +228,7 @@ Stack <Boon name="Might"/> (you can use <SpecialActionKey name="hypernovalaunch"
 
 <Grid>
 <GridItem sm="9">
+
 |                                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Blinding Radiance**                 | Similar to the other bosses, Arkk has the white beam ability which damages players facing him and inflicts <Condition name="Blinded"/> and <Condition name="fear"/>. It is easily recognizable by a large eye icon above Arkk. If you have problems receiving damage despite looking away, try to wiggle left/right while turned away to minimize the risk.                                                                                                                                                                                                                                                                                                                                                                  |

--- a/fractals/sirens-reef/index.md
+++ b/fractals/sirens-reef/index.md
@@ -19,6 +19,7 @@ sigils:
 
 <Grid>
 <GridItem sm="12">
+
 ## Start: Wipe out the dinosaurs!
 
 When you enter the fractal, first you need to kill 2 _Veteran Bristlebacks_, 2 _Veteran Smogscales_ and 1 _Veteran Bonebreaker_. After you killed them, you need to move to the rock wall to kill the _Champion Stonehead_. Break his breakbar to kill it easily. After killing it, he will <Condition name="Fear"/> you back and die in the mines. Use the cannon to clear out the mines to gain access to the next encounter.
@@ -37,6 +38,7 @@ When you enter the fractal, first you need to kill 2 _Veteran Bristlebacks_, 2 _
 </GridItem>
 
 <GridItem sm="12">
+
 ## The Forgotten Fortress
 
 Prestack boons on the _Mistlock Singularity_ nearby.
@@ -63,6 +65,7 @@ _Blast Black Peter_ the skeleton boss is kind of a DPS race. He starts spawning 
 
 <Grid>
 <GridItem sm="12">
+
 ## The Maze
 
 ### The treasures
@@ -92,6 +95,7 @@ Your objective is simple. You need to collect 3 treasures and carry them to the 
 </GridItem>
 
 <GridItem sm="6">
+
 ### The way to the ship
 
 Here you have to get the chest onto the ship by throwing the treasure chest at each other, same tactic as before. You can use the _Mistlock Singularity_ at the entrance to reset your cooldowns. If you happen to be in combat (you triggered the AoE circles) then just skip it and take it when you '/gg' before you fight Arabella Crowe (it is to reset mobs from the previous event and to start with no cd and fresh boons).
@@ -104,6 +108,7 @@ Here you have to get the chest onto the ship by throwing the treasure chest at e
 
 <Grid>
 <GridItem sm="6">
+
 ### Retrieve the second treasure
 
 You need to get a chest again, now from one of the shores (random which one). Use same tactic as before, throw the chest across. There are 2 cannons each side of the ship, use it to clear mobs easily. After recovering the treasure the first mini boss spawns named _Mad Jack Squall_. During the boss there will be AoEs across the ship that blows players down the ship into the poisonous water. These AoEs cannot be ignored with <Boon name="Stability"> so avoid standing in them to stay on the platform. Kill him to start the next objective.</Boon>

--- a/fractals/snowblind/index.md
+++ b/fractals/snowblind/index.md
@@ -28,6 +28,7 @@ consumables: [78978, 49940]
 
 <Grid>
 <GridItem sm="8">
+
 Light up the *Bonfire* with your special action key skill. Kill the spawning *Icebrood Elementals* or use control effects like <Control name="Pull"/> to prevent them from extinguishing it and throw *Firewood* into the fire to keep it burning. The stronger the bonfire, the faster the ice wall will melt - usually after around 75 seconds.
 
 If you gain too many stacks of _Hypothermia_ (one every 5 seconds), reset them by standing at the bonfire.
@@ -56,6 +57,7 @@ First swap your legend to <Skill name="Legendary Centaur Stance"/> / <Skill name
 
 <Grid>
 <GridItem sm="6">
+
 ## Elemental Source
 
 At the start of the fight, light up the five bonfires to remove the 10 stacks of _Rime Shield_ from the boss. Each stack reduces its damage taken by 10%.
@@ -96,6 +98,7 @@ With the right angle, you can <Skill id="5697"/> against the Elemental Source.
 </GridItem>
 
 <GridItem sm="7">
+
 ## Forest <Item id="8883" disableText/><Item id="24667" disableText/>
 
 After the Elemental Source is destroyed, everyone except the fastest player can `/gg` and wait for the next checkpoint at the cave to trigger. Mobility skills and <Item id="85244"/> / <Item id="49940"/> are very good here, **skip videos below**.
@@ -124,6 +127,7 @@ After the Elemental Source is destroyed, everyone except the fastest player can 
 
 <Grid>
 <GridItem sm="8">
+
 ## Shaman Lornarr Dragonseeker <Item id="8883" disableText/><Item id="24667" disableText/>
 
 Stack <Boon name="Might"/> before the final boss. Make sure to dodge into the boss room to avoid getting <Condition name="Chilled"/> from the icy bolts.

--- a/fractals/solid-ocean/index.md
+++ b/fractals/solid-ocean/index.md
@@ -20,6 +20,7 @@ sigils:
 
 <Grid>
 <GridItem sm="12">
+
 ## Start
 
 You have to run to the boss first, the only obstacle in your way is your own jumping puzzle skill and the _Irukandji_, _Jade Shards_. The way to the boss is not really challenging as it can be ran through fast. If you happen to be in combat, jumping through will be a little bit harder but nothing extraordinary. Use <Effect name="Stealth"/> to skip the mobs easily. Before doing the final jump onto the boss platform next to the Mistlock Singularity, make sure to have <Boon name="Swiftness"/> so you don't fall to your death because there will be <Effect name="Agony"/> applied to you mid-air.
@@ -53,7 +54,7 @@ You have to run to the boss first, the only obstacle in your way is your own jum
 
 Before you approach the boss, stack <Boon name="Might"/> and kill the two _Jade Tentacles_, then the _Irukandji_. The _Jade Tentacles_ have two skill, a huge spin AoE (so make sure to dodge it the right time) and after the spin, a stomping attack that can be side-stepped or dodged. Note that the tentacles can be CC'd like <Control name="Stun"/> or <Control name="Daze"/>.
 
-After killing the _Jade Tentacles_ new ones appear and the _Jade Maw_ starts tagging players with a red skull and _Jade Colossi_ starts spawning. The red skull is an indicator of an insta-downing skill which happens after the skull disappears from above the player. The skull **can be dodged when the red skull disappears** but mainly you want to **pick up the Reflecting Crystals spawned by the _Jade Colossi_ and the _Jade Tentacles_ and throw them into the \_Jade Maw's Eye, this is the only way it can be damaged** as normal skills won't damage him at all.
+After killing the _Jade Tentacles_ new ones appear and the _Jade Maw_ starts tagging players with a red skull and _Jade Colossi_ starts spawning. The red skull is an indicator of an insta-downing skill which happens after the skull disappears from above the player. The skull **can be dodged when the red skull disappears** but mainly you want to **pick up the Reflecting Crystals spawned by the _Jade Colossi_ and the _Jade Tentacles_ and throw them into the Jade Maw's Eye, this is the only way it can be damaged** as normal skills won't damage him at all.
 
 **DO NOT** kill all _Jade Tentacles_ at once but move as a group from tentacle to tentacle as every tentacle cost the _Jade Maw_ a small amount of HP, which however does not stack, if you kill them at the same time.
 

--- a/fractals/sunqua-peak/index.md
+++ b/fractals/sunqua-peak/index.md
@@ -53,6 +53,7 @@ Killing elementals spawns lightning strikes that periodically leave behind an or
 
 <Grid>
 <GridItem sm="7">
+
 The Voice of the mountain is the first boss in the fractal. This boss deals little damage, however, its basic attack will knock you back, stay in max melee range to avoid that. Every 33%, the boss gets <Effect name="Invulnerability"/> and summons a tornado, tethered to 4 clouds. Lightning strikes appear shortly after and leave the same collectable orbs as before. You must collect 3 and jump into the clouds to disperse them, using the <Uncategorized name="chargedleap"/> buff. Players are also targeted by <Skill id="61190"/>, red AoEs  that deal heavy damage and apply <Condition name="Vulnerability"/> and <Condition name="Weakness"/>. Keep moving to avoid their damage.
 </GridItem>
 
@@ -70,6 +71,7 @@ The Voice of the mountain is the first boss in the fractal. This boss deals litt
 <Grid>
 <GridItem sm="8">
 <Warning>
+
 Not a single trash mob needs to be killed for progression!
 </Warning>
 
@@ -83,6 +85,7 @@ After the Voice of the mountain is dead, take the updraft and follow the path. I
 </GridItem>
 
 <GridItem sm="12">
+
 However, the waterfalls have two states, active and inactive. When inactive, they will not push you over the edge. An easy way to tell which state they are in is if the water flow is more intense with more white streaks running through it or not. When the effects expire and the flow slows down, it's safe to simply walk through it. Alternatively, you can also try and dodge through the intense flow or use <Item id="85244"/> or a movement skill to quickly get past. The second waterfall can be easily skipped by walking behind it.
 
 Do the mini jumping puzzle to the 2nd boss, remember to talk to the elementals. As soon as you have interacted with all 3, `/gg` so your team can catch up with the front runner.
@@ -95,6 +98,7 @@ Do the mini jumping puzzle to the 2nd boss, remember to talk to the elementals. 
 
 <Grid>
 <GridItem sm="8">
+
 The second boss of the fractal is a big pile of rocks. Avoid the orange AoEs that appear by dodging or by using <Boon name="Aegis"/>. Whoever is closest to the dark orb on the side of the arena gets tethered to it and receives the debuff <Uncategorized name="tidalbargain"/> that increases over time. Upon reaching 10 stacks, the tethered player will go down or their mistlock will be removed. To avoid this, another player should take the tether by running inside the beam, between the orb and the tethered player, and stay there for at least a second.
 </GridItem>
 
@@ -115,6 +119,7 @@ The second boss of the fractal is a big pile of rocks. Avoid the orange AoEs tha
 </GridItem>
 
 <GridItem sm="8">
+
 There are stone piles blocking the way. Kill the lava elementals before each pile to progress along the path. Use <Control name="Pull"/>s and burst them down quickly.
 </GridItem>
 </Grid>
@@ -133,6 +138,7 @@ There are stone piles blocking the way. Kill the lava elementals before each pil
 
 <Grid>
 <GridItem sm="8">
+
 The third boss of the fractal is the Fury of the mountain. Every 33% it gets <Effect name="Invulnerability"/> and spawns two AoEs with intensity circles that drop meteors from the sky, leaving rocks behind.
 
 At 66%, the meteors fall in set positions, while at 33%, two random players are each targeted by a meteor. Standing inside the circle inflicts <Condition name="Burning"/> and deals damage that scales with your distance to the epicenter of the impact. The yellow shockwave does not deal any physical damage but applies more <Condition name="Burning"/>.
@@ -156,6 +162,7 @@ Kill the boss and move on to the final encounter of this fractal.
 This section explains CM and non-CM. The first part is for both the same, except that the Sorrowful Spellcaster has more HP and hits harder on CM. Mechanically it is the same.
 
 <Warning>
+
 When you break Ai's breakbar she gets a buff on her bar preventing a new breakbar from spawning for 30 seconds. The breakbar has an insane size of 3200 making it hard to break. It is recommended to bring all the CC skills your class provides.
 </Warning>
 
@@ -163,6 +170,7 @@ When you break Ai's breakbar she gets a buff on her bar preventing a new breakba
 
 <Grid>
 <GridItem sm="8">
+
 The Sorrowful Spellcaster is the fourth and final boss of the fractal. Unlike other fractal CM encounters, pre-booning does not work, because once you cross the green circle around the boss all boons will get removed. However, you can still precast unique buffs like <Skill name="Bane Signet"/> or <Skill name="One Wolf Pack"/>.
 
 The boss has multiple phases themed around the different elements air, fire, water. The previously introduced mechanics are reoccurring.
@@ -179,6 +187,7 @@ The boss has multiple phases themed around the different elements air, fire, wat
 
 <Grid>
 <GridItem xs="12" sm="7">
+
 After crossing the green line, the fight starts. After about one second, Ai dashes to a randomly chosen side and casts a set of line attacks. During this time, a CC bar appears which **should not be broken** (you can CC Ai in the middle, you get no orange AoEs, means more DPS for not spreading out due to the circle mechanic). After the line attacks, she will dash to the middle and target each player with an orange AoE, forcing the group to split up to minimize damage taken (**only if you break Ai's first CC bar, or don't break Ai's 2nd CC bar in the middle**). When the circles disappear, group up (avoiding any subsequent lines or explosions) and start bursting. If you have not broken the 1st CC bar, a second will appear, as Ai starts casting a series of cone attacks.
 </GridItem>
 
@@ -187,6 +196,7 @@ After crossing the green line, the fight starts. After about one second, Ai dash
 </GridItem>
 
 <GridItem xs="12" sm="12">
+
 Breaking the bar at the last second is key for maximum DPS. To do this, you need to remember the pattern of upcoming attacks when the CC bar is active. That pattern is 2 cones, multihit circles (that must be dodged), another cone and finally, a red AoE that deals massive damage and forces the group to split. Break the bar when the red circle appears and stay in the middle, upkeeping DPS.
 
 If you do not manage to bring her to 66%, she will dash twice and get <Effect name="Invulnerability"/>, summoning a tornado, like the Voice of the Mountain. Approach this phase as you did before, only this time, you must disperse 8 clouds quickly, or Ai will cast a massive AoE that wipes the group. Keep in mind that a set of 3 <Uncategorized name="chargedleap"/> orbs spawn in each cardinal direction. Split up accordingly and move in the same direction to interrupt this attack as quickly as possible.
@@ -201,10 +211,12 @@ If you do not manage to bring her to 66%, she will dash twice and get <Effect na
 </GridItem>
 
 <GridItem xs="12" sm="7">
+
 After bringing the boss down to 66%, she gets <Effect name="Invulnerability"/> and spawns meteor impact AoEs. Outrun them like a turtle. After the third set of impacts the boss reappears. Be aware, there is a fourth set of 4 meteor impacts in a square formation around the boss. Dodge them! Two players are also targeted by meteor AoEs that fall shortly after the final 4. They should be placed outside of the stack (in a non-static team), or just ignore them by dodging at the right time (in a coordinated team).
 </GridItem>
 
 <GridItem xs="12" sm="12">
+
 After all, meteors have fallen, an AoE around the boss starts to expand, launching a powerful attack that downs/strips mistlock from anyone caught in the blast. Seek shelter behind a rock (this is the same pattern as in the Fury of the Mountain encounter). Be aware, there will only be one rock in Challenge Mode. The ''fake'' rocks are ones that glow red before crumbling. The safe rock is **always** the southwest one on the minimap.
 
 After the meteor attack, the pattern from the Air Phase repeats. If you do not manage to bring her to 33% in the middle, she will dash twice and instead of the tornado attack, she will summon additional meteors.
@@ -215,6 +227,7 @@ After the meteor attack, the pattern from the Air Phase repeats. If you do not m
 
 <Grid>
 <GridItem xs="12" sm="7">
+
 After bringing the boss down to 33%, she gets <Effect name="Invulnerability"/> and pushes the group to the edge. After a short while, dark orbs appear on set intervals that tether to players. The player closest to the orb gets tethered and receives the debuff <Uncategorized name="tidalbargain"/>. You can take over the <Uncategorized name="tidalbargain"/> by standing in-between the tethered person and the orb. Players are also targeted by green AoEs, stay stacked to share the damage taken.
 
 After the 4th orb disappears, the boss dashes to the side and repeats the same pattern as before, only this time she starts casting a more powerful version of the previous line attacks, summoning water tornados that deal heavy damage. Be very careful and avoid them.
@@ -225,6 +238,7 @@ After the 4th orb disappears, the boss dashes to the side and repeats the same p
 </GridItem>
 
 <GridItem xs="12" sm="12">
+
 If you do not manage to bring her to 1% in the middle, she will dash twice and instead of the meteor attack, she will cast a water tornado, reflecting all projectiles and pulling players in. Standing in this tornado deals damage and applies agony every second. She also casts line attacks that deal damage but can be avoided by standing out of the way. Keep in mind that she is still vulnerable, but she takes reduced damage. Previous mechanics like the <Uncategorized name="tidalbargain"/> orbs and green AoEs are present during this attack.
 </GridItem>
 </Grid>
@@ -238,6 +252,7 @@ After a long roleplay, Ai transforms into her demon form and the whole arena get
 #### Pre-Sorrow<Label>100%-66%</Label>
 
 <Warning>
+
 Be aware that every time a person dies, a Doubt spawns. It behaves like a Vindicator from <Instability name="Fractal Vindicators"/>. Don't forget to assign 2 people for CCing Sorrow at 66% and a third person to CC the 2 Sorrows near Guilt for maximum efficiency!
 </Warning>
 
@@ -247,10 +262,12 @@ Be aware that every time a person dies, a Doubt spawns. It behaves like a Vindic
 </GridItem>
 
 <GridItem xs="12" sm="7">
+
 After recovering from being tethered by her Doubt the boss will initially dash in a random direction into the wall and start her attack pattern. Be careful to not stand in her dash path or to simply dodge through it as it deals heavy damage. Upon hitting the wall lasers will start to spawn in a set attack pattern that will be consistent throughout the fight this is also when the first breakbar appears which lasts 7 seconds. The hitboxes of the lasers are quite thin and it is, therefore, possible to stand in-between two lasers and not get hit.
 </GridItem>
 
 <GridItem xs="12" sm="12">
+
 After 5 waves of lasers, Ai will dash again in a random direction towards a wall. This is when the first split-phase will occur, a bunch of heavy ticking damage AoE's will spawn around the boss as well as very large expanding circles around each player. Make sure to spread out to avoid heavy damage. She will then do a series of basic attacks before finally doing another split phase with a slightly different AoE pattern on the floor (this is the same basic attack pattern as the one in all previous phases, mentioned in the air phase).
 </GridItem>
 </Grid>
@@ -262,6 +279,7 @@ From this point onward the boss will mostly stay in the center of the arena, das
 #### Sorrow <Label>66%-33%</Label>
 
 <Warning>
+
 Any AoE's on the floor prior to her hitting 66% will still last the full duration so be careful when walking back to the center
 </Warning>
 
@@ -273,10 +291,12 @@ Upon hitting 66% the boss will stop any current animation and fizzle any current
 </GridItem>
 
 <GridItem xs="12" sm="8">
+
 At the same time a Sorrow will spawn, this mob will spawn at a random position inside the middle ring of AoE's a few seconds after the boss begins channeling. You can tell where the Sorrow will spawn a few seconds before it actually does thanks to a small area of the arena lighting up at its eventual spawn location. The Sorrow will start channeling a devastating attack that will instantly down the whole party if it completes channeling. To prevent this the Sorrow must be killed or its breakbar must be broken.
 </GridItem>
 
 <GridItem xs="12" sm="12">
+
 Ranged CC such as <Skill name="Sanctuary"/> or <Skill name="Darkrazors Daring"/> is preferable as you get to stay inside the safe zone near the boss.
 </GridItem>
 </Grid>

--- a/fractals/swampland/index.md
+++ b/fractals/swampland/index.md
@@ -35,6 +35,7 @@ sigils:
 
 <Grid>
 <GridItem sm="8">
+
 ## Running the wisps
 
 Trigger the start event by walking to the three _Wisp Clefts_ in the South. Wait for three players to be ready at each of the randomly spawned Wisps, usually indicated by typing `ready` in chat. Count down to go and deliver the Wisps to the Clefts within 30 seconds while avoiding <Control name="Stun"/>, <Condition name="Immobile"/> and <Condition name="crippled"/> from the spike, wire and hunting traps on the ground.
@@ -79,6 +80,7 @@ Use <Skill id="13038"/> or <Skill id="13002"/> for fast delivery.
 
 <Grid>
 <GridItem sm="8">
+
 In the passage, the Mossman is waiting to fight you. You can break his defiance bar while he is in <Effect name="Stealth"/> to force a reveal and make him <Effect name="Exposed"/>. Walk to the *Mistlock Singularity* inside the Bloomhunger's lair to reset your cooldown and pre-stack some boons.
 
 <Warning>
@@ -97,6 +99,7 @@ In the passage, the Mossman is waiting to fight you. You can break his defiance 
 
 <Grid>
 <GridItem sm="8">
+
 ## Bloomhunger
 
 Activate the encounter by placing the nearby Wisp into an empty Wisp Cleft. Bloomhunger (and all trash mobs) are only vulnerable inside the active Wisp Cleft area, additionally all players gain 100% increased endurance regeneration from it. The active area switches clockwise, move to the next position as soon as it decreases in size.

--- a/fractals/thaumanova-reactor/index.md
+++ b/fractals/thaumanova-reactor/index.md
@@ -40,6 +40,7 @@ sigils:
 
 <Grid>
 <GridItem sm="8">
+
 ## Start
 
 Activate the _Detonator_ and wait for the <Specialization name="Renegade"/>, <Specialization name="Weaver"/>, <Specialization name="Guardian"/> or <Specialization name="Daredevil"/> to open a portal with <Item id="78978"/> (the rest of the group stacks <Boon name="Might"/> in the vestibule) or if no one can skip just walk up to the _Elite Flame Legion Fire Shaman_. Kill him, `/gg` to reset your cooldowns and split up to disable the four colliders.
@@ -77,6 +78,7 @@ Activate the _Detonator_ and wait for the <Specialization name="Renegade"/>, <Sp
 <Grid>
 <GridItem sm="12">
 <Warning>
+
 For a faster completion time you can split up. <Specialization name="Berserker"/> activates Subject 6 <Label>Northwest</Label>. <Specialization name="Guardian"/> soloes Repulsor lab<Label>South</Label>. <Specialization name="Weaver"/> soloes Superheated Room <Label>West</Label> and <Specialization name="Renegade"/> and <Specialization name="Soulbeast"/> do Researcher Dormitories <Label>East</Label>.
 </Warning>
 </GridItem>
@@ -86,12 +88,14 @@ For a faster completion time you can split up. <Specialization name="Berserker"/
 
 <Tabs>
 <Tab specialization="Guardian">
+
 If you decide to do it with 2 people ping anyone with least DPS to come help you.
 </Tab>
 </Tabs>
 </GridItem>
 
 <GridItem sm="5">
+
 ## Repulsor lab <Label>South</Label>
 
 This should be done by two people, **but can be soloed (usually by <Specialization name="Guardian"/>) as shown in the video below**. Learn the timing of the turret shots and jump or dodge over them. You can also take a _Safety Shield_ from the beginning and use it to block shots for a short duration.
@@ -110,6 +114,7 @@ Activating <Label>2</Label> enables short access to the two final consoles at <L
 
 <Grid>
 <GridItem sm="8">
+
 ## Researcher Dormitories <Label>East</Label>
 
 2 people (usually <Specialization name="Renegade"/> and <Specialization name="Soulbeast"/>) should do this area immediately after the Elite Flame Legion Fire Shaman. Remember to destroy the Unstable Portals as well. Finishing this event in time will grant you a 10% damage boost for the endboss.
@@ -132,6 +137,7 @@ Activating <Label>2</Label> enables short access to the two final consoles at <L
 </GridItem>
 
 <GridItem sm="8">
+
 ## Superheated Room <Label>West</Label>
 
 This is usually soloed by the <Specialization name="Weaver"/> but other classes can do it as well, like in the **video shown below**.
@@ -170,6 +176,7 @@ This is usually soloed by the <Specialization name="Weaver"/> but other classes 
 
 <Grid>
 <GridItem>
+
 ## Ooze Room: Subject 6 <Label>Northwest</Label>
 
 Gather at Subject 6 after finishing the other three colliders. During the fight, small and large (at 75%/50/25% health) Oozes will spawn and move toward it slowly, restoring its health when they reach it. Subject 6 also has a easily distinguishable _Shield Form_, hitting him then will give him stacks of _Overload_. Reaching 20 stacks results in a party wipe.
@@ -188,10 +195,12 @@ Requires high damage and you may have to wait a while as the blocking occurs at 
 
 <Tabs>
 <Tab specialization="Daredevil">
+
 Share <Skill id="13132"/> with 5 allies to deal 750 unblockable defiance bar damage.
 </Tab>
 
 <Tab specialization="Berserker">
+
 Equip <Skill id="14404"/> to make your CC skills unblockable.<Video youtube="XjRteFiMY2Y"/>
 </Tab>
 </Tabs>
@@ -202,6 +211,7 @@ Equip <Skill id="14404"/> to make your CC skills unblockable.<Video youtube="XjR
 
 <Grid>
 <GridItem sm="8">
+
 ## Thaumanova Anomaly
 
 After all four colliders are disabled, use `/gg` to reset any cooldowns and resurrect directly at the Thaumanova Anomaly console. Activate it to teleport up and stack <Boon name="Might"/>.\

--- a/fractals/twilight-oasis/index.md
+++ b/fractals/twilight-oasis/index.md
@@ -95,6 +95,7 @@ Treat each Sandbinder like any immobile boss and attack accordingly. Keep in min
 </GridItem>
 
 <GridItem sm="8">
+
 ## Priestess Amala (Basic)
 
 Next up you will encounter Priestess Amala for the first time, bring her to 75% health and she wipes your party to praise Joko.
@@ -111,6 +112,7 @@ You can freely use `/gg` after she downs the party to reset cooldowns, just wait
 
 <Grid>
 <GridItem sm="7">
+
 Now that you're awakened, you gain access to a new special action skill which launches you high into the air and breaks <Control name="Stun"/>. It doesn't have a cooldown out of combat so do not get in fight during skips if possible.
 
 It can also be used to jump while casting any skill that requires you to stand still otherwise, as long as you do not move in any direction (<Skill id="5501" profession="Weaver"/> and similar skills).
@@ -157,6 +159,7 @@ Stack <Boon name="Might"/> and be ready to dodge the initial <Control name="Knoc
 
 <Grid>
 <GridItem sm="9">
+
 ### Permanent Mechanics
 
 |                                     |                                                                                                                                                                                          |

--- a/fractals/uncategorized/index.md
+++ b/fractals/uncategorized/index.md
@@ -39,6 +39,7 @@ consumables: [78978, 49940, 8764, 8801]
 
 <Grid>
 <GridItem sm="7">
+
 ## Start
 
 **Option 1 (recommended):** The whole party stacks <Effect name="Stealth"/> and skips together until the holding area. If a single Harpy spawned immediately at the begin, you can kill it before stealthing.
@@ -57,18 +58,22 @@ Reflects are strong here as well, especially against the Fire Shaman's projectil
 
 <Tabs>
 <Tab specialization="Weaver">
+
 If positioned correctly, you can use <Skill id="5697"/> against the wall and deal lots of damage to the adds.
 </Tab>
 
 <Tab specialization="Berserker">
+
 Equip a greatsword and <Skill name="blood reckoning"/> for double <Skill name="arc divider"/>. Use your greatsword to cleave down the adds quickly!
 </Tab>
 
 <Tab specialization="Firebrand">
+
 Try to share <Boon name="Aegis"/> with your group by using <Skill name="Mantra of Solace"/> when the Ettin is about to hit the group.
 </Tab>
 
 <Tab specialization="Holosmith">
+
 You can use <Skill name="Holographic Shockwave"/> and <Skill name="Primelight Beam"/> to help break the defiance bars. Try to land those skills on all adds!
 </Tab>
 </Tabs>
@@ -77,15 +82,16 @@ You can use <Skill name="Holographic Shockwave"/> and <Skill name="Primelight Be
 <GridItem sm="5">
 <Tabs>
 <Tab specialization="Thief">
-Use the smoke field from <Skill id="13113"/> or <Skill id="13065" profession="Daredevil"/> or simply cast <Skill id="13117"/> to stack <Effect name="Stealth"/>.\
-<Skill id="13065"/> is also useful against the Holding Area bosses.
+Use the smoke field from <Skill id="13113"/> or <Skill id="13065" profession="Daredevil"/> or simply cast <Skill id="13117"/> to stack <Effect name="Stealth"/>. <Skill id="13065"/> is also useful against the Holding Area bosses.
 </Tab>
 
 <Tab specialization="Ranger">
+
 Use <Skill id="31568"/> from your Smokescale pet and blast the smoke field to stack <Effect name="Stealth"/>.
 </Tab>
 
 <Tab specialization="Engineer">
+
 You can spec into <Specialization name="Scrapper"/> and use the <Skill name="Sneak Gyro"/> which grants lots of <Effect name="Stealth"/> for your party. Alternatively, use <Skill id="5824"/> in the <Skill name="Bomb Kit"/> for a smoke field which you can then blast to stack <Effect name="Stealth"/>.
 </Tab>
 </Tabs>
@@ -98,6 +104,7 @@ You can spec into <Specialization name="Scrapper"/> and use the <Skill name="Sne
 
 <Grid>
 <GridItem sm="8">
+
 ## Pulsing Orbs
 
 After killing the adds, walk past the three Harpies and run up the ramp towards Old Tom. You can dodge through or reflect the pulsing orbs and even skip the last part by walking on the left wall.
@@ -118,6 +125,7 @@ Note: Activating all three consoles at the same time will turn off the turrets. 
 </GridItem>
 
 <GridItem sm="8">
+
 ## Old Tom <Item id="8887" disableText/><Item id="24672" disableText/>
 
 Stack <Boon name="Might"/> before Old Tom, break his defiance bar as quickly as possible and burst him down. Be careful with <Effect name="Agony"/> and try to not stand in his hitbox or very close to him while he is firing his projectiles. <Specialization name="Soulbeast"/> can use <Skill id="12489"/> or take <Skill name="Bear stance"/> with the trait <Trait name="Leader of the Pack"/> to help out with the Poison from the green projectiles.
@@ -128,6 +136,7 @@ Stack <Boon name="Might"/> before Old Tom, break his defiance bar as quickly as 
 
 <Grid>
 <GridItem sm="5">
+
 ## Raving Asura <Item id="8887" disableText/><Item id="24672" disableText/>
 
 Stack <Effect name="Stealth"/> before the Harpies and jump to the top. As soon as someone reaches the top level, you can safely use `/gg` and resurrect at the checkpoint there. Watch your objectives list on the top right of the screen. As soon as you see a change in the objective you have triggered the checkpoint and may use `/gg`.

--- a/fractals/underground-facility/index.md
+++ b/fractals/underground-facility/index.md
@@ -115,6 +115,7 @@ Use <Skill id="31568"/> from your Smokescale pet to stack <Effect name="Stealth"
 
 <Grid>
 <GridItem sm="8">
+
 After resurrecting, skip the mobs with <Effect name="Stealth"/> and the guns or nine bombs to destroy the gate.
 
 On the **rifles** path you lose all your endurance and therefore you are unable to dodge. Walk to the gate with an equipped rifle and avoid the orange AoEs on the ramp. If you get hit by an AoE the rifle is no longer usable and you have to pick up a new one. Use the rifle skill 1 to damage the gate. Note that using a portal with a new rifle causes it to become unusable. **Only use a portal to get back from the gate.**
@@ -162,6 +163,7 @@ Skip here by one of the classes below:
 
 <Grid>
 <GridItem sm="7">
+
 If you did not skip, stack <Effect name="Stealth"/> and skip towards the Endboss together.
 
 After loosing potential aggro of the mobs from the corridor, pull the boss to the next lava bucket, trigger it to inflict _Superheated_ for 10x damage and nuke. Stay on the boss as long as possible before moving to the next bucket but pay attention to his _Mending_ heal skill, which can be interrupted by simply attacking him as long as the Superheated debuff is up.

--- a/fractals/urban-battlegrounds/index.md
+++ b/fractals/urban-battlegrounds/index.md
@@ -41,6 +41,7 @@ sigils:
 </GridItem>
 
 <GridItem sm="6">
+
 ## Siegemaster Dulfy
 
 Stack <Effect name="Stealth"/> in the tent and run towards Dulfy.
@@ -51,14 +52,17 @@ Killing the _Burning Oil_ above her is your highest priority. Control and cleave
 <GridItem sm="12">
 <Tabs>
 <Tab specialization="elementalist">
+
 If you are the first Weaver at the gate and still have <Effect name="Stealth"/>, cast <Skill id="5501"/> on the Burning Oil above Dulfy. At least one weaver should use <Skill id="5738"/> on the mobs and Dulfy. You can use <Skill id="5697"/> against the door for more damage. Use <Skill id="22572"/> for better cleave.
 </Tab>
 
 <Tab specialization="ranger">
+
 Use <Skill id="31568"/> from your Smokescale pet to stack <Effect name="Stealth"/> at the beginning.
 </Tab>
 
 <Tab specialization="thief">
+
 Use the smoke field from <Skill id="13113"/> or <Skill name="Smoke Screen" profession="thief"/> (also useful for reflects) or simply cast <Skill id="13117"/> to stack <Effect name="Stealth"/>.
 </Tab>
 </Tabs>
@@ -71,6 +75,7 @@ Use the smoke field from <Skill id="13113"/> or <Skill name="Smoke Screen" profe
 
 <Grid>
 <GridItem sm="6">
+
 Again, stack <Effect name="Stealth"/> and skip past all the mob groups. Plan ahead to not run into any obstacles. Gather after reaching the courtyard.
 
 Note that there is a little jumping puzzle in case you are unlucky with barricades spawning, check out [this video](https://www.youtube.com/watch?v=d5uTRJ9iyEY) for reference. Using <Item id="8764"/> and <Item id="8801"/> also helps not aggroing the guards nearby. Watch out for the chicken that spawns there for an achievement (it is random if it's there or not), putting you in combat using the items, thus not being able to pull off the skip.
@@ -98,6 +103,7 @@ Use <Skill id="31568"/> from your Smokescale pet to stack <Effect name="Stealth"
 
 <Grid>
 <GridItem sm="6">
+
 ## Courtyard
 
 To capture the courtyard, you have to kill (or kite away) four groups of _Veteran Ascalonians_.
@@ -117,8 +123,7 @@ For more experienced groups it is favorable to take <Skill name="Legendary Dwarf
 
 <Tabs>
 <Tab specialization="elementalist">
-<Skill id="5738"/> is very strong against the groups of mobs during the capture event. <Skill id="5671"/> and <Skill id="5683"/> prevent the enemy warriors *Rush* attack.\
-Stay in <Skill id="5492"/> before Ashym for <Boon name="Might"/> stacking.
+<Skill id="5738"/> is very strong against the groups of mobs during the capture event. <Skill id="5671"/> and <Skill id="5683"/> prevent the enemy warriors *Rush* attack. Stay in <Skill id="5492"/> before Ashym for <Boon name="Might"/> stacking.
 </Tab>
 </Tabs>
 </GridItem>

--- a/fractals/volcanic/index.md
+++ b/fractals/volcanic/index.md
@@ -32,6 +32,7 @@ consumables: [78978, 49940]
 
 <Grid>
 <GridItem sm="6">
+
 While four people kill the respawning Grawls to fill the progress bar, one person (usually the <Specialization name="Renegade"/> but anyone can run) should run ahead to the next area and trigger the checkpoint at the *Grawl Shaman*. This way, everyone can portal after the section is completed and resurrect to skip the Boulder passage. <Specialization name="Elementalist"/> can precast strong DPS skills like <Skill id="5737"/> and <Skill id="5501"/> on the spawn locations of the Grawls, since the mobs take damage seconds before they actually appear. You can use <Skill id="5738"/> to reduce incoming damage and <Skill id="22572"/> to cleave the adds faster. <Specialization name="Berserker"/> can equip a greatsword and <Skill name="bloodreckoning"/> for 2x <Skill name="arcdivider"/>!
 </GridItem>
 
@@ -64,13 +65,14 @@ While four people kill the respawning Grawls to fill the progress bar, one perso
 <GridItem sm="5">
 <Tabs>
 <Tab specialization="Weaver">
-Use either <Skill id="5683"/> and <Skill id="5686"/> or <Skill id="5671"/> to keep the *Veteran Grawl Shamans* in your <Skill id="5548"/>, <Skill id="43762"/> and <Skill id="41125"/>.\
-If everyone LoS'ed the boss correctly, he will be close enough to <Skill id="5697"/> against the altar he stood on.
+
+Use either <Skill id="5683"/> and <Skill id="5686"/> or <Skill id="5671"/> to keep the *Veteran Grawl Shamans* in your <Skill id="5548"/>, <Skill id="43762"/> and <Skill id="41125"/>. If everyone LoS'ed the boss correctly, he will be close enough to <Skill id="5697"/> against the altar he stood on.
 </Tab>
 </Tabs>
 </GridItem>
 
 <GridItem sm="7">
+
 ## Grawl Shaman <Item id="8890" disableText/><Item id="24648" disableText/>
 
 Kill the _Veteran Grawl Shamans_ to prevent them from sacrificing the captives. Control effects like <Control name="Stun"/> and <Condition name="Immobile"/> hinder them from reaching the edge.
@@ -89,6 +91,7 @@ After the bubble is broken, stand below the boss to LoS him and he will come dow
 
 <Grid>
 <GridItem sm="8">
+
 **Take the shortcut on the right-hand side down, jump into the lava then run and jump to the final platform to trigger the next checkpoint**, then everyone uses `/gg` to reset cooldowns. Walk until the end of the boardwalk, stack <Boon name="Might"/> and jump down to the Imbued Shaman (the bat follows you to the end of the walkway, but it takes 10 or more seconds to reach it. Make sure you have the boons stacked and are on the correct weapon before she flies in you fire field).
 
 Every 25% health, it gains a protective bubble and starts moving to a random villager. It will heal for about 20% health if it reaches their target, so break the bubble quickly by casting 40 offensive abilities while targeting the Imbued Shaman (you actually don't have to hit him). Try to keep him in the center as the villagers are located at the edge of the area.

--- a/guides/damage-mitigation/index.md
+++ b/guides/damage-mitigation/index.md
@@ -15,6 +15,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 <Grid>
 <GridItem sm="4">
 <Card specialization="Revenant">
+
 -   <Skill name="Protective Solace"/>  <Specialization name="Revenant" disableText/>  \
     (Ventari Utility)
 
@@ -23,6 +24,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Mesmer">
+
 -   <Skill id="10302"/> <Specialization name="Mesmer" disableText/>   \
     (Utility, best used during <Skill id="29830" disableText/>, <Specialization name="Chronomancer" disableText/>)
 
@@ -40,6 +42,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Warrior">
+
 -   <Skill id="30074"/> <Specialization name="Berserker" disableText/>  \
     (Utility skill)
 
@@ -57,6 +60,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Elementalist">
+
 -   <Skill id="5685"/> <Specialization name="Elementalist" disableText/>  \
     (Staff 3, <Skill id="5495" disableText/>)
 
@@ -74,6 +78,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Ranger">
+
 -   <Skill id="12639"/> <Specialization name="Ranger" disableText/>  \
     (Axe 5)
 
@@ -85,6 +90,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Guardian">
+
 -   <Skill id="9251"/> <Specialization name="Guardian" disableText/>  \
     (Utility skill)
 
@@ -105,6 +111,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Thief">
+
 -   <Skill name="Punishing Strikes"/> <Specialization name="Thief" disableText/>  \
     (3rd Autoattack)
 
@@ -125,6 +132,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 
 <GridItem sm="4">
 <Card specialization="Necromancer">
+
 -   <Skill name="Corrosive Poison Cloud"/> <Specialization name="Necromancer" disableText/>  \
     (Utility skill)
 
@@ -142,6 +150,7 @@ Below is a list of currently used projectile reflect or absorb skills and traits
 Certain mechanics can be bypassed by using block, evade, <Effect name="Invulnerability"/> or <Boon name="Aegis"/> skills. Those ward against any attack (including projectiles) and usually prevent the application of conditions and control effects.
 
 <Warning>
+
 Note that some abilities are unblockable!
 </Warning>
 
@@ -150,6 +159,7 @@ Below is a list of commonly used defensive skills:
 <Grid>
 <GridItem sm="4">
 <Card specialization="Revenant">
+
 -   <Skill name="Warding Rift"/>  <Specialization name="Revenant" disableText/>  \
     (Staff 3)
 
@@ -170,6 +180,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Mesmer">
+
 -   <Skill id="10192"/> <Specialization name="Mesmer" disableText/>  \
     (F4, personal evade)\
     You can trait <Trait id="1852"/> to share <Boon name="Aegis" disableText/> with allies (5 seconds internal cooldown) when you gain distortion
@@ -197,6 +208,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Warrior">
+
 -   <Skill name="Whirlwind Attack"/> <Specialization name="Warrior" disableText/>  \
     (Mace 2)
 
@@ -219,6 +231,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Elementalist">
+
 -   <Skill id="5641"/> <Specialization name="Elementalist" disableText/>  \
     (Utility skill)
 
@@ -242,6 +255,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Ranger">
+
 -   <Skill name="Signet of Stone" profession="Ranger"/> <Specialization name="Ranger" disableText/>  \
     (Utility)
 
@@ -253,6 +267,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Guardian">
+
 -   <Skill id="9102"/> <Specialization name="Guardian" disableText/>  \
     (Heal skill)
 
@@ -283,6 +298,7 @@ Below is a list of commonly used defensive skills:
 
 <GridItem sm="4">
 <Card specialization="Thief">
+
 -   <Skill id="30661"/> <Specialization name="Daredevil" disableText/>  \
     (Utility skill)
 

--- a/guides/fractal-basics/index.md
+++ b/guides/fractal-basics/index.md
@@ -32,8 +32,10 @@ Starting with tier 2 the heroes are encountering _Mistlock instabilities_ which 
 Have you noticed the blue bar under the boss' HP bar? Whenever you use a Crowd Control skill (a skill that throws the enemy around, stuns or applies movement impaling conditions) a chunk of the bar gets removed. When the entire bar is broken the boss gets the <Effect name="Exposed"/> debuff which increases the incoming damage to the boss by 50%. **This is one of the most important mechanics across all fractals as this allows you to deal huge amounts of damage in a short time.** The idea is to always break this bar and then burst. Ideally everyone in the team contributes to break the bar as it appears.
 
 <Warning>
+
 **Using Crowd Control effectively is the key to success in almost all fractals! A fast break will decrease kill times by a large margin even if your party underperforms in every other aspect!**  \
 Read more about breaking Defiance bars here: [CC-distribution examples](/guides/cc-distribution)!
+
 </Warning>
 
 ---
@@ -168,6 +170,7 @@ Please consult the [meta-page](guides/meta-explained) for more information about
 
 <Grid>
 <GridItem sm="8">
+
 You can use the chat command `/gg` within fractals to immediately kill your character (dead, not downed). This can be used generously in fractal skips, as it allows the entire party to teleport to a checkpoint once one player activates it.
 
 If everyone in the party is dead at the same time, cooldowns will reset for all players. Therefore it is advised for the entire group to use `/gg` at certain key positions to reset long cooldowns, like between Siax (2nd boss) and Ensolyss (3rd boss) in Nightmare CM. Never resurrect as long as another player is still alive. If another player tells you `/gg` he is probably doing a skip that you are unaware of or he wasn't ready for combat yet. Either way, do not waste time questioning it.
@@ -192,11 +195,13 @@ Note that the <Specialization name="Warrior"/>'s Adrenaline bar, <Specialization
 </GridItem>
 
 <GridItem sm="12" md="6">
+
 After maxing the fractal masteries to level 4 you get access to *Mistlock Singularities*. Taking one of these will reset the cooldowns of all your skills! This allows you to precast certain skills before entering the battle without a penalty. It makes sense to precast <Boon name="Quickness"/>, <Boon name="Alacrity"/> and use blast finishers on certain Combo Fields.
 
 The most common applications are <Boon name="Might"/>-stacking using blast finishers inside a _Fire Field_ (3 stacks for 20 seconds with boon duration) and <Effect name="Stealth"/>-stacking inside a _Smoke Field_ (3 seconds).
 
 <Warning>
+
 Do not use other combo fields than fire on the *Mistlock Singularity*! All combo fields but the *Fire Field* are useless in terms of prebooning.
 </Warning>
 </GridItem>
@@ -273,6 +278,7 @@ Be careful not to aggro mobs with blasts or you will get <Effect name="Revealed"
 </GridItem>
 
 <GridItem sm="12" md="6">
+
 #### Other skills that grant party <Effect name="Stealth"/>
 
 - <Specialization name="Mesmer"/>:
@@ -296,6 +302,7 @@ Be careful not to aggro mobs with blasts or you will get <Effect name="Revealed"
 
 <Grid>
 <GridItem sm="12" md="6">
+
 In many Fractals the concept of "Line of Sight" can be applied to pack mobs together without using any skills that <Control name="Pull"/>. As soon as a player takes aggro of a mob it tries to attack the player. In doing so it needs to find a valid path. For enemies with melee weapons this means it will run right towards you, ranged enemies need a clear sight towards the player without obstruction. After taking aggro of a mob the player wants to move behind a wall so the mob loses Line of Sight and is forced to take the shortest path to the player.
 
 Generally, you **always** want to stick together as a group. Reason being that boons and unique buffs won't reach players that are standing too far away. Since most classes deal high damage in melee the logical conclusion is to stack up, pull mobs together either with <Control name="Pull"/>s or Line of Sight and burst them down as quickly as possible. **Even if the amount of enemies seems dangerous at the first glance the most secure position on the map is in the center of the stack!**
@@ -361,10 +368,12 @@ Below is a list of all current instabilities and their possible countermeasures.
 </GridItem>
 
 <GridItem sm="11" md="11">
+
 Mistlocked \[FotM] is a Guild & Discord Server focused on teaching new members of the Guild Wars 2 community the various aspects of Fractals of the Mist!\
 While Fractals are their main focus, they do offer other training & organized groups for Raids, as well as Strike Missions, and Dungeons!
 
 All information is available on their [discord](https://discord.gg/CE3TswT).
+
 </GridItem>
 </Grid>
 

--- a/guides/what-should-i-play/index.md
+++ b/guides/what-should-i-play/index.md
@@ -19,6 +19,7 @@ Outline:
 <Divider text="Meta builds"/>
 
 <Card specialization="Soulbeast">
+
 | Build                                                                            | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Soulbeast" disableLink/>](/builds/ranger/power-soulbeast) | <Rating value="5"/> | <Rating value="5"/> | <Rating value="3"/> | <Rating value="3"/> | <Rating value="4"/> |
@@ -42,6 +43,7 @@ Overall this is a very well rounded build that is rewarding to play in both PuGs
 </Card>
 
 <Card specialization="Renegade">
+
 | Build                                                                            | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Renegade" disableLink/>](/builds/revenant/power-renegade) | <Rating value="5"/> | <Rating value="2"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="5"/> |
@@ -54,6 +56,7 @@ Since the <Specialization name="Renegade"/> is a power-oriented build it benefit
 </Card>
 
 <Card specialization="Firebrand">
+
 | Build                                                                             | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | --------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Firebrand" disableLink/>](/builds/revenant/power-renegade) | <Rating value="5"/> | <Rating value="3"/> | <Rating value="4"/> | <Rating value="2"/> | <Rating value="4"/> |
@@ -65,11 +68,13 @@ It plays very similar to <BuildLink build="Power Dragonhunter" specialization="D
 Using <Skill name="Bane Signet"/> to break defiance bars also increases your allies' <Attribute name="Power"/> by 216 for 10 seconds thanks to <Trait name="Perfect Inscriptions"/>.
 
 <Warning>
+
 Its worth to mention that *<Specialization text="Power Quickness Firebrand" name="Firebrand"/>* is exceedingly strong when bosses phase quickly. For various T4 fractals, long fights or if you happen to be in a slower group (most PuG groups), you want to run *<BuildLink build="Condi Firebrand" specialization="Firebrand"/>* as it provides much higher sustained DPS.
 </Warning>
 </Card>
 
 <Card specialization="Dragonhunter" title="Power Dragonhunter">
+
 | Build                                                                                    | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ---------------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Dragonhunter" disableLink/>](/builds/guardian/power-dragonhunter) | <Rating value="3"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="2"/> | <Rating value="4"/> |
@@ -88,6 +93,7 @@ It benefits from slaying potions such as <Item id="50082"/> and <Item name="Impa
 <Divider text="Condi Meta builds"/>
 
 <Card specialization="Firebrand" title="Condi Firebrand">
+
 | Build                                                                              | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ---------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Firebrand" disableLink/>](/builds/guardian/condi-firebrand) | <Rating value="3"/> | <Rating value="4"/> | <Rating value="5"/> | <Rating value="2"/> | <Rating value="3"/> |
@@ -115,6 +121,7 @@ Overall this build is one of the best picks for newer players, for PuGs as <Boon
 </Card>
 
 <Card specialization="Renegade" title="Condi Alac Renegade">
+
 | Build                                                                                 | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ------------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Renegade" disableLink/>](/builds/revenant/condi-alac-renegade) | <Rating value="4"/> | <Rating value="3"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="5"/> |
@@ -127,6 +134,7 @@ Even if Condi <Specialization name="Renegade"/> does less damage than a <BuildLi
 </Card>
 
 <Card specialization="Soulbeast" title="Condi Soulbeast">
+
 | Build                                                                            | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Soulbeast" disableLink/>](/builds/ranger/condi-soulbeast) | <Rating value="5"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="2"/> | <Rating value="3"/> |
@@ -146,6 +154,7 @@ Overall this is a very well rounded build that is rewarding to play in both PuGs
 </Card>
 
 <Card specialization="Deadeye" title="Condi Deadeye">
+
 | Build                                                                      | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Deadeye" disableLink/>](builds/thief/condi-deadeye) | <Rating value="3"/> | <Rating value="5"/> | <Rating value="3"/> | <Rating value="2"/> | <Rating value="4"/> |
@@ -160,6 +169,7 @@ Overall, this build is an excellent pick if taken as an alt class: it is meant f
 <Divider text="Power Offmeta builds"/>
 
 <Card specialization="Weaver">
+
 | Build                                                                            | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Weaver" disableLink/>](/builds/elementalist/power-weaver) | <Rating value="4"/> | <Rating value="5"/> | <Rating value="2"/> | <Rating value="3"/> | <Rating value="4"/> |
@@ -172,6 +182,7 @@ Also this build depends pretty much on supports and boon uptimes, as it can't pr
 </Card>
 
 <Card specialization="Berserker">
+
 | Build                                                                             | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | --------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Berserker" disableLink/>](/builds/warrior/power-berserker) | <Rating value="4"/> | <Rating value="4"/> | <Rating value="4"/> | <Rating value="2"/> | <Rating value="4"/> |
@@ -186,6 +197,7 @@ Furthermore, the build is able to use damage modifying sigils like <Item name="I
 </Card>
 
 <Card specialization="Holosmith" title="Power Holosmith">
+
 | Build                                                                              | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ---------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Holosmith" disableLink/>](/builds/engineer/power-holosmith) | <Rating value="2"/> | <Rating value="4"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="4"/> |
@@ -196,6 +208,7 @@ The build benefits from slaying potions such as <Item id="50082"/> and <Item nam
 </Card>
 
 <Card specialization="Reaper" title="Power Reaper">
+
 | Build                                                                           | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Reaper" disableLink/>](/builds/necromancer/power-reaper) | <Rating value="1"/> | <Rating value="3"/> | <Rating value="4"/> | <Rating value="2"/> | <Rating value="3"/> |
@@ -208,6 +221,7 @@ It benefits from slaying potions such as <Item id="50082"/> and <Item name="Impa
 </Card>
 
 <Card specialization="Chronomancer" title="Power Chronomancer">
+
 | Build                                                                                  | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Chronomancer" disableLink/>](/builds/mesmer/power-chronomancer) | <Rating value="2"/> | <Rating value="4"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="4"/> |
@@ -226,6 +240,7 @@ This build profits from sigils like <Item name="Impact" type="Sigil"/> as well a
 <Divider text="Condi Offmeta builds"/>
 
 <Card specialization="Scourge" title="Condi Scourge">
+
 | Build                                                                             | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | --------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Scourge" disableLink/>](/builds/necromancer/condi-scourge) | <Rating value="2"/> | <Rating value="4"/> | <Rating value="4"/> | <Rating value="2"/> | <Rating value="3"/> |
@@ -240,6 +255,7 @@ Due to being a condition based build, it will not benefit as highly from slaying
 </Card>
 
 <Card specialization="Weaver" title="Condi Weaver">
+
 | Build                                                                            | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | -------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Weaver" disableLink/>](/builds/elementalist/condi-weaver) | <Rating value="3"/> | <Rating value="5"/> | <Rating value="3"/> | <Rating value="4"/> | <Rating value="5"/> |
@@ -256,11 +272,13 @@ The main downside of **<Specialization text="Condi Weaver" name="Weaver"/>** apa
 <Divider text="Heal builds"/>
 
 <Card specialization="Firebrand" title="Heal Firebrand">
+
 | Build                                                                             | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | --------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Firebrand" disableLink/>](/builds/guardian/heal-firebrand) | <Rating value="4"/> | <Rating value="1"/> | <Rating value="3"/> | <Rating value="1"/> | <Rating value="2"/> |
 
 <Warning>
+
 This build is very common in PuGs. It is part of a composition called PuG Meta. More info about this composition can be found [here](/guides/meta-explained). This build provides a high amount of boons and a lot of safety to the group via its healing. It therefore shines most in less experienced groups as well as when you have bad instabilities. Once the safety of a dedicated healer is no longer needed, you can move on to running [Power Firebrand](/builds/guardian/power-firebrand) or [Condi Firebrand](/builds/guardian/condi-firebrand). We also added a hybrid variant that is in-between the full heal and damage versions called [Seraph Firebrand](/builds/guardian/seraph-firebrand) for parties wanting to transition to no heal runs.
 </Warning>
 
@@ -274,14 +292,15 @@ If you play this build we highly recommend learning the <Skill name="Bane Signet
 </Card>
 
 <Card specialization="Firebrand" title="Seraph Firebrand">
+
 | Build                                                                               | Synergy             | DPS                 | Independence        | Basics              | Mastery             |
 | ----------------------------------------------------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
 | [<Specialization name="Firebrand" disableLink/>](/builds/guardian/seraph-firebrand) | <Rating value="4"/> | <Rating value="3"/> | <Rating value="4"/> | <Rating value="3"/> | <Rating value="4"/> |
 
-The **<Specialization text="Seraph Firebrand" name="Firebrand"/>** is a build for groups to use instead of a **<Specialization text="Heal Firebrand" name="Firebrand"/>**. It provides more than enough healing for most groups, permanent <Boon name="Quickness"/>, a large chunk (15-18 stacks) of <Boon name="might"/> and on demand <Boon name="Stability"/> and <Boon name="Aegis"/>, whilst dealing a decent amount of damage. It is especially strong in PuGs where often a **<Specialization text="Heal Firebrand" name="Firebrand"/>** is overkill, especially in condi groups, but the convenience of having a more supportive player pumping out important boons such as <Boon name="might"/>, <Boon name="Stability"/>, <Boon name="Aegis"/> and heals is invaluable. \
-\
- It plays very similar to <BuildLink build="Condi Firebrand" specialization="Firebrand"/>, except that the damage output is significantly lowered due to slotting the Honor trait line. \
-\
+The **<Specialization text="Seraph Firebrand" name="Firebrand"/>** is a build for groups to use instead of a **<Specialization text="Heal Firebrand" name="Firebrand"/>**. It provides more than enough healing for most groups, permanent <Boon name="Quickness"/>, a large chunk (15-18 stacks) of <Boon name="might"/> and on demand <Boon name="Stability"/> and <Boon name="Aegis"/>, whilst dealing a decent amount of damage. It is especially strong in PuGs where often a **<Specialization text="Heal Firebrand" name="Firebrand"/>** is overkill, especially in condi groups, but the convenience of having a more supportive player pumping out important boons such as <Boon name="might"/>, <Boon name="Stability"/>, <Boon name="Aegis"/> and heals is invaluable. 
+
+ It plays very similar to <BuildLink build="Condi Firebrand" specialization="Firebrand"/>, except that the damage output is significantly lowered due to slotting the Honor trait line. 
+
  The general idea of this build is to leverage the Seraph stat combo (<Attribute name="Precision"/>, <Attribute name="Healing Power"/>, <Attribute name="Condition Damage"/> and <Attribute name="Concentration"/>). This gives a high amount of <Attribute name="Healing Power"/> and <Attribute name="Condition Damage"/>. It then uses Runes, Sigils and Food to cap <Condition name="Burning"/> duration allowing you to deal a good amount of damage. There are three variants shown below; a Seraph variant, Celestial variant and a Celestial Heal variant. The Seraph Variant is a more offensive build and offers the most damage. The Celestial variant is slightly less damage but also a better option than Seraph for raids and strikes. While the Celestial Heal variant is much more supportive and a last resort before swapping to <BuildLink build="Heal Firebrand" specialization="Firebrand"/>.
 </Card>
 


### PR DESCRIPTION
This primarily adds newlines before markdown text embedded within JSX components, which fixes rendering when rendered with MDX 1.6 (i.e. on the site, but not in the CMS preview, which at this moment uses MDX 2.0 because MDX is confusing.)

It also removes a few stray escape characters, some of which were added by DxCx's script in #588, and some random typo'd control characters. I really should have committed those separately, but I didn't do these in order and I'm not gonna go find them all again :P

I still don't know how to get this pattern (newlines inside lists) to work in MDX 1.6, so I left it as is. See the weaver rotations to see what I mean.

1. text
  moretext
2. text

Fun aside, here's a regex that finds opening JSX tags that aren't followed by either two newlines or another component. (`$1/n/n$2` being the replacement to add another newline.)

```
(<[^/\n]+>)
([^<\n])
```