### PR TITLE
Format character jsx

### DIFF
--- a/builds/elementalist/condi-weaver/index.md
+++ b/builds/elementalist/condi-weaver/index.md
@@ -26,102 +26,97 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Guardian",
-                  "title":"162 Ar", "weight":"Heavy", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ],  "attributes": {
-                  "Health": 11645,
-                  "Armor": 2210,
-                  "Power": 3368,
-                  "Precision": 2006,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 270,
-                  "Condition Damage": 2929,
-                  "Expertise": 743,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.7953333333333333,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.829047619047619,
-                  "Critical Damage": 1.68,
-                  "Burning Duration": 0.20,
-                  "Bleeding Duration": 0.20,
-                  "Effective Power": 8744.397760999998,
-                  "Power DPS": 9427.922114285711,
-                  "Burning Damage": 950.616875,
-                  "Burning Stacks": 25.540266666666668,
-                  "Burning DPS": 24279.008485333336,
-                  "Bleeding Damage": 321.3275,
-                  "Bleeding Stacks": 32.3244,
-                  "Bleeding DPS": 10386.718641,
-                  "Poison Damage": 340.015,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 480.04125000000005,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 321.3275,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 44093.64924061905,
-                  "Effective Health": 34421164.375,
-                  "Survivability": 17499.32098373157,
-                  "Effective Healing": 390,
-                  "Healing": 390
-        }, "runeId":24800, "runeName":"Elementalist", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType":"Sword",
-                  "weapon1MainSigil1":"Earth",
-                  "weapon1OffType":"Focus",
-                  "weapon1OffSigil":"Geomancy"
-              }, "consumables":{
-                  "foodId": "91876",
-                  "utilityId": "48917",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of Restoration",
-                  "utility1": "Glyph of Elemental Power",
-                  "utility2": "Primordial Stance",
-                  "utility3": "Signet of Fire",
-                  "elite": "Weave Self"
-                } 
-              }}
-      >  
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "title": "162 Ar",
+          "weight": "Heavy",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 11645,
+            "Armor": 2210,
+            "Power": 3368,
+            "Precision": 2006,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 270,
+            "Condition Damage": 2929,
+            "Expertise": 743,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.7953333333333333,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.829047619047619,
+            "Critical Damage": 1.68,
+            "Burning Duration": 0.2,
+            "Bleeding Duration": 0.2,
+            "Effective Power": 8744.397760999998,
+            "Power DPS": 9427.922114285711,
+            "Burning Damage": 950.616875,
+            "Burning Stacks": 25.540266666666668,
+            "Burning DPS": 24279.008485333336,
+            "Bleeding Damage": 321.3275,
+            "Bleeding Stacks": 32.3244,
+            "Bleeding DPS": 10386.718641,
+            "Poison Damage": 340.015,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 480.04125000000005,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 321.3275,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 44093.64924061905,
+            "Effective Health": 34421164.375,
+            "Survivability": 17499.32098373157,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24800,
+          "runeName": "Elementalist",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "Earth",
+            "weapon1OffType": "Focus",
+            "weapon1OffSigil": "Geomancy"
+          },
+          "consumables": {
+            "foodId": "91876",
+            "utilityId": "48917",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Signet of Restoration",
+            "utility1": "Glyph of Elemental Power",
+            "utility2": "Primordial Stance",
+            "utility3": "Signet of Fire",
+            "elite": "Weave Self"
+          }
+        }}
+      >
 
 
       Note that the build does not rely on precision as much as the <BuildLink build="Power Weaver" specialization="Weaver"/> variant and you can build your Agony Resistance around the 150 breakpoint. You should however aim for a fully +9 stated infusion gear setup for maximum <Item id="79722"/> stat conversion value. The stats shown are with 162 Agony Resistance.  This build requires 16x <Item name="malignagonyinfusion"/> and 2x <Item name="spitefulagonyinfusion"/>.  

--- a/builds/elementalist/power-weaver/index.md
+++ b/builds/elementalist/power-weaver/index.md
@@ -22,109 +22,95 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Elementalist",
-                  "weight":"Light", "gear": [
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 14155,
-          "Armor": 2210,
-          "Power": 3941,
-          "Precision": 2575,
-          "Toughness": 1243,
-          "Vitality": 1251,
-          "Ferocity": 1972,
-          "Condition Damage": 750,
-          "Expertise": 0,
-          "Concentration": 243,
-          "Healing Power": 0,
-          "Agony Resistance": 162,
-          "Condition Duration": 0,
-          "Boon Duration": 0.162,
-          "Critical Chance": 1.00,
-          "Critical Damage": 2.814666666666667,
-          "Burning Duration": 0.20,
-          "Effective Power": 32261.918293667994,
-          "Power DPS": 44970.4059388056,
-          "Burning Damage": 370.875,
-          "Burning Stacks": 8.04,
-          "Burning DPS": 2981.8349999999996,
-          "Bleeding Damage": 100.5,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 117.75,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 148.95,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 100.5,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 47952.2409388056,
-          "Effective Health": 57207963.31250001,
-          "Survivability": 29083.865435943066,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131
-        ],
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Sword",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Dagger",
-          "weapon1OffSigilId": 24868
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Glyph of Elemental Harmony",
-          "utility1": "Primordial Stance",
-          "utility2": "Glyph of Storms",
-          "utility3": "Arcane Blast",
-          "elite": "Conjure Fiery Greatsword"
-                } 
-      }}
-
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Elementalist",
+          "weight": "Light",
+          "gear": [
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 14155,
+            "Armor": 2210,
+            "Power": 3941,
+            "Precision": 2575,
+            "Toughness": 1243,
+            "Vitality": 1251,
+            "Ferocity": 1972,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.162,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.814666666666667,
+            "Burning Duration": 0.2,
+            "Effective Power": 32261.918293667994,
+            "Power DPS": 44970.4059388056,
+            "Burning Damage": 370.875,
+            "Burning Stacks": 8.04,
+            "Burning DPS": 2981.8349999999996,
+            "Bleeding Damage": 100.5,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 117.75,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 148.95,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 100.5,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 47952.2409388056,
+            "Effective Health": 57207963.31250001,
+            "Survivability": 29083.865435943066,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Dagger",
+            "weapon1OffSigilId": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Glyph of Elemental Harmony",
+            "utility1": "Primordial Stance",
+            "utility2": "Glyph of Storms",
+            "utility3": "Arcane Blast",
+            "elite": "Conjure Fiery Greatsword"
+          }
+        }}
       >
-
 
       If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>.
 
@@ -134,212 +120,190 @@ sections:
 
       </Character> 
 
-      <Character title="222 Agony Resistance" 
-                 gear={{ "profession": "Elementalist",
-                  "weight":"Light", "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 14205,
-          "Armor": 2300,
-          "Power": 4031,
-          "Precision": 2575,
-          "Toughness": 1333,
-          "Vitality": 1256,
-          "Ferocity": 1966,
-          "Condition Damage": 750,
-          "Expertise": 0,
-          "Concentration": 333,
-          "Healing Power": 0,
-          "Agony Resistance": 222,
-          "Condition Duration": 0,
-          "Boon Duration": 0.222,
-          "Critical Chance": 1.00,
-          "Critical Damage": 2.8106666666666666,
-          "Burning Duration": 0.20,
-          "Effective Power": 32951.78334349984,
-          "Power DPS": 45932.01990892161,
-          "Burning Damage": 370.875,
-          "Burning Stacks": 8.04,
-          "Burning DPS": 2981.8349999999996,
-          "Bleeding Damage": 100.5,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 117.75,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 148.95,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 100.5,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 48913.85490892161,
-          "Effective Health": 59748005.62500001,
-          "Survivability": 30375.19350533808,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131
-        ],
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Sword",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Dagger",
-          "weapon1OffSigilId": 24868
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Glyph of Elemental Harmony",
-          "utility1": "Primordial Stance",
-          "utility2": "Glyph of Storms",
-          "utility3": "Arcane Blast",
-          "elite": "Conjure Fiery Greatsword"
-        } 
-      }}> 
+      <Character
+        title="222 Agony Resistance"
+        gear={{
+          "profession": "Elementalist",
+          "weight": "Light",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 14205,
+            "Armor": 2300,
+            "Power": 4031,
+            "Precision": 2575,
+            "Toughness": 1333,
+            "Vitality": 1256,
+            "Ferocity": 1966,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 333,
+            "Healing Power": 0,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.222,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.8106666666666666,
+            "Burning Duration": 0.2,
+            "Effective Power": 32951.78334349984,
+            "Power DPS": 45932.01990892161,
+            "Burning Damage": 370.875,
+            "Burning Stacks": 8.04,
+            "Burning DPS": 2981.8349999999996,
+            "Bleeding Damage": 100.5,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 117.75,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 148.95,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 100.5,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 48913.85490892161,
+            "Effective Health": 59748005.62500001,
+            "Survivability": 30375.19350533808,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Dagger",
+            "weapon1OffSigilId": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Glyph of Elemental Harmony",
+            "utility1": "Primordial Stance",
+            "utility2": "Glyph of Storms",
+            "utility3": "Arcane Blast",
+            "elite": "Conjure Fiery Greatsword"
+          }
+        }}
+      > 
 
 
       You need <Item id="85743"/>, <Item id="86175"/>, 18x +9 Agony Infusions and also <Item id="70596"/>. <br/>  If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>.  Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants! 
 
       </Character> 
 
-      <Character title="245 Agony Resistance" 
-                 gear={{ "profession": "Elementalist",
-                  "weight":"Light", "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 14215,
-          "Armor": 2335,
-          "Power": 4057,
-          "Precision": 2575,
-          "Toughness": 1368,
-          "Vitality": 1257,
-          "Ferocity": 1963,
-          "Condition Damage": 750,
-          "Expertise": 0,
-          "Concentration": 368,
-          "Healing Power": 0,
-          "Agony Resistance": 245,
-          "Condition Duration": 0,
-          "Boon Duration": 0.24533333333333335,
-          "Critical Chance": 1.00,
-          "Critical Damage": 2.808666666666667,
-          "Burning Duration": 0.20,
-          "Effective Power": 33214.2428365642,
-          "Power DPS": 46297.86641061317,
-          "Burning Damage": 370.875,
-          "Burning Stacks": 8.04,
-          "Burning DPS": 2981.8349999999996,
-          "Bleeding Damage": 100.5,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 117.75,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 148.95,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 100.5,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 49279.70141061317,
-          "Effective Health": 60699915.71875001,
-          "Survivability": 30859.133563167263,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          49438,
-          49438,
-          49438,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131
-        ],
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Sword",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Dagger",
-          "weapon1OffSigilId": 24868
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Glyph of Elemental Harmony",
-          "utility1": "Primordial Stance",
-          "utility2": "Glyph of Storms",
-          "utility3": "Arcane Blast",
-          "elite": "Conjure Fiery Greatsword"
-        } 
-      }}>  
+      <Character
+        title="245 Agony Resistance"
+        gear={{
+          "profession": "Elementalist",
+          "weight": "Light",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 14215,
+            "Armor": 2335,
+            "Power": 4057,
+            "Precision": 2575,
+            "Toughness": 1368,
+            "Vitality": 1257,
+            "Ferocity": 1963,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 368,
+            "Healing Power": 0,
+            "Agony Resistance": 245,
+            "Condition Duration": 0,
+            "Boon Duration": 0.24533333333333335,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.808666666666667,
+            "Burning Duration": 0.2,
+            "Effective Power": 33214.2428365642,
+            "Power DPS": 46297.86641061317,
+            "Burning Damage": 370.875,
+            "Burning Stacks": 8.04,
+            "Burning DPS": 2981.8349999999996,
+            "Bleeding Damage": 100.5,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 117.75,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 148.95,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 100.5,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 49279.70141061317,
+            "Effective Health": 60699915.71875001,
+            "Survivability": 30859.133563167263,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 49438, 49438, 49438, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Dagger",
+            "weapon1OffSigilId": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Glyph of Elemental Harmony",
+            "utility1": "Primordial Stance",
+            "utility2": "Glyph of Storms",
+            "utility3": "Arcane Blast",
+            "elite": "Conjure Fiery Greatsword"
+          }
+        }}
+      >  
 
 
       You need <Item id="85743"/>, <Item id="86175"/>, 3x <Item id="49438"/>, with the rest being 15x +9 Agony Infusions. You also need <Item id="70596"/> and the 5 AR from _Mistlock Singularity_. <br/>  If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>. 

--- a/builds/engineer/power-holosmith/index.md
+++ b/builds/engineer/power-holosmith/index.md
@@ -48,101 +48,95 @@ sections:
     content: >-
       <CharacterWithAr> 
 
-      <Character title="150 Agony Resistance" 
-                 gear={{ "profession": "Engineer",
-                  "weight":"Medium", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2343,
-                  "Power": 3496,
-                  "Precision": 2286,
-                  "Toughness": 1225,
-                  "Vitality": 1000,
-                  "Ferocity": 1756,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 225,
-                  "Healing Power": 0,
-                  "Agony Resistance": 150,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.15,
-                  "Critical Chance": 1.1123809523809524,
-                  "Critical Damage": 2.6706666666666666,
-                  "Bleeding Duration": 0.33,
-                  "Effective Power": 30616.976963743986,
-                  "Power DPS": 42677.49580621996,
-                  "Burning Damage": 355.421875,
-                  "Burning Stacks": 4,
-                  "Burning DPS": 1421.6875,
-                  "Bleeding Damage": 96.3125,
-                  "Bleeding Stacks": 15.561,
-                  "Bleeding DPS": 1498.7188125,
-                  "Poison Damage": 112.84375,
-                  "Poison Stacks": 2,
-                  "Poison DPS": 225.6875,
-                  "Torment Damage": 142.74375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 96.3125,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 45823.58961871996,
-                  "Effective Health": 51294713.25,
-                  "Survivability": 26077.637646161667,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType":"Sword",
-                  "weapon1MainSigil1":"Force",
-                  "weapon1OffType":"Shield",
-                  "weapon1OffSigil":"Impact"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "Superior Sharpening Stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "A.E.D",
-                  "utility1": "Grenade Kit",
-                  "utility2": "Rifle Turret",
-                  "utility3": "Laser Disk",
-                  "elite": "Prime Light Beam"
-                } 
-              }}
-      > 
+      <Character
+        title="150 Agony Resistance"
+        gear={{
+          "profession": "Engineer",
+          "weight": "Medium",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2343,
+            "Power": 3496,
+            "Precision": 2286,
+            "Toughness": 1225,
+            "Vitality": 1000,
+            "Ferocity": 1756,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 225,
+            "Healing Power": 0,
+            "Agony Resistance": 150,
+            "Condition Duration": 0,
+            "Boon Duration": 0.15,
+            "Critical Chance": 1.1123809523809524,
+            "Critical Damage": 2.6706666666666666,
+            "Bleeding Duration": 0.33,
+            "Effective Power": 30616.976963743986,
+            "Power DPS": 42677.49580621996,
+            "Burning Damage": 355.421875,
+            "Burning Stacks": 4,
+            "Burning DPS": 1421.6875,
+            "Bleeding Damage": 96.3125,
+            "Bleeding Stacks": 15.561,
+            "Bleeding DPS": 1498.7188125,
+            "Poison Damage": 112.84375,
+            "Poison Stacks": 2,
+            "Poison DPS": 225.6875,
+            "Torment Damage": 142.74375,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 96.3125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 45823.58961871996,
+            "Effective Health": 51294713.25,
+            "Survivability": 26077.637646161667,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "Force",
+            "weapon1OffType": "Shield",
+            "weapon1OffSigil": "Impact"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "Superior Sharpening Stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "A.E.D",
+            "utility1": "Grenade Kit",
+            "utility2": "Rifle Turret",
+            "utility3": "Laser Disk",
+            "elite": "Prime Light Beam"
+          }
+        }}
+      >
 
 
       Due to the naturally high crit-chance from the Firearms Trait Line, this build does not rely on high Agony Resistance to reach crit-cap. You will only need higher Agony Resistance or Assassin pieces if you want to swap to <Trait name="Sanguine Array"/> for better self-generated <Boon name="Might"/>.  You can use Off-Hand Pistol if there is absolutely no need for the CC from Shield. 

--- a/builds/guardian/condi-firebrand/index.md
+++ b/builds/guardian/condi-firebrand/index.md
@@ -37,104 +37,98 @@ sections:
     content: >-
       <CharacterWithAr> 
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Sinister",
-                  "Sinister",
-                  "Viper",
-                  "Sinister",
-                  "Sinister",
-                  "Sinister",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 14145,
-                  "Armor": 2514,
-                  "Power": 2869,
-                  "Precision": 2085,
-                  "Toughness": 1243,
-                  "Vitality": 1250,
-                  "Ferocity": 300,
-                  "Condition Damage": 3188,
-                  "Expertise": 451,
-                  "Concentration": 243,
-                  "Healing Power": 250,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.30066666666666666,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.8666666666666666,
-                  "Critical Damage": 1.70,
-                  "Burning Duration": 0.70,
-                  "Resolution Duration": 0.25,
-                  "Effective Power": 7222.552095833332,
-                  "Power DPS": 6674.672710820176,
-                  "Burning Damage": 1078.3664999999999,
-                  "Burning Stacks": 30.8,
-                  "Burning DPS": 33213.6882,
-                  "Bleeding Damage": 319.92,
-                  "Bleeding Stacks": 6.113133333333334,
-                  "Bleeding DPS": 1955.7136160000002,
-                  "Poison Damage": 337.17,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 478.08000000000004,
-                  "Torment Stacks": 1.5608,
-                  "Torment DPS": 746.187264,
-                  "Confusion Damage": 319.92,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 42590.26179082017,
-                  "Effective Health": 48895728.75,
-                  "Survivability": 24858.021733604473,
-                  "Effective Healing": 465,
-                  "Healing": 465
-              }, "runeId":24765, "runeName":"Balthazar", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1": "Earth",
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigil": "Bursting",
-                  "weapon2MainType": "Scepter",
-                  "weapon2MainSigil1": "Geomancy"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-focusing-crystal",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility1": "Mantra of Potence",
-                  "utility2": "Purging Flames",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      > 
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Sinister",
+            "Sinister",
+            "Viper",
+            "Sinister",
+            "Sinister",
+            "Sinister",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 14145,
+            "Armor": 2514,
+            "Power": 2869,
+            "Precision": 2085,
+            "Toughness": 1243,
+            "Vitality": 1250,
+            "Ferocity": 300,
+            "Condition Damage": 3188,
+            "Expertise": 451,
+            "Concentration": 243,
+            "Healing Power": 250,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.30066666666666666,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.8666666666666666,
+            "Critical Damage": 1.7,
+            "Burning Duration": 0.7,
+            "Resolution Duration": 0.25,
+            "Effective Power": 7222.552095833332,
+            "Power DPS": 6674.672710820176,
+            "Burning Damage": 1078.3664999999999,
+            "Burning Stacks": 30.8,
+            "Burning DPS": 33213.6882,
+            "Bleeding Damage": 319.92,
+            "Bleeding Stacks": 6.113133333333334,
+            "Bleeding DPS": 1955.7136160000002,
+            "Poison Damage": 337.17,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 478.08000000000004,
+            "Torment Stacks": 1.5608,
+            "Torment DPS": 746.187264,
+            "Confusion Damage": 319.92,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 42590.26179082017,
+            "Effective Health": 48895728.75,
+            "Survivability": 24858.021733604473,
+            "Effective Healing": 465,
+            "Healing": 465
+          },
+          "runeId": 24765,
+          "runeName": "Balthazar",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1": "Earth",
+            "weapon1OffType": "Torch",
+            "weapon1OffSigil": "Bursting",
+            "weapon2MainType": "Scepter",
+            "weapon2MainSigil1": "Geomancy"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "toxic-focusing-crystal",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility1": "Mantra of Potence",
+            "utility2": "Purging Flames",
+            "utility3": "Sanctuary",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       Note that this build variant gains boon duration from the <Item id="79722"/> and <Item id="48916"/>. To keep up permanent <Boon name="Quickness"/> you will need to reach 24.6% boon duration. For longer fights drop <Item id="24560"/> for <Item id="72339"/>.

--- a/builds/guardian/heal-firebrand/index.md
+++ b/builds/guardian/heal-firebrand/index.md
@@ -28,100 +28,94 @@ sections:
     content: >-
       <CharacterWithAr> 
 
-      <Character title="Heal Firebrand" 
-                 gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Harrier",
-                  "Harrier",
-                  "Harrier",
-                  "Harrier",
-                  "Harrier",
-                  "Harrier",
-                  "Harrier",
-                  "Cleric",
-                  "Harrier",
-                  "Cleric",
-                  "Cleric",
-                  "Cleric",
-                  "Harrier",
-                  "Harrier"
-              ], "attributes":{
-                  "Health": 17145,
-                  "Armor": 2787,
-                  "Power": 3035,
-                  "Precision": 1323,
-                  "Toughness": 1516,
-                  "Vitality": 1550,
-                  "Ferocity": 300,
-                  "Condition Damage": 1038,
-                  "Expertise": 0,
-                  "Concentration": 1121,
-                  "Healing Power": 1712,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.9973,
-                  "Critical Chance": 0.5038,
-                  "Critical Damage": 1.70,
-                  "Burning Duration": 1.05,
-                  "Effective Power": 5901.431,
-                  "Power DPS": 575.749,
-                  "Burning Damage": 0,
-                  "Burning Stacks": 0,
-                  "Burning DPS": 0,
-                  "Bleeding Damage": 0,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 0,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 0,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 0,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 575.749,
-                  "Healing": 720.39
-              }, "runeId":24842, "runeName":"Monk", "infusions":[
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125,
-                  37125
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1": "transference",
-                  "weapon1OffType": "Shield",
-                  "weapon1OffSigil": "concentration",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "transference",
-                  "weapon2MainSigil2": "concentration"
-              }, "consumables":{
-                  "foodId": "91690",
-                  "utility": "bountiful-maintenance-oil",
-                  "infusion": "Healing +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility1": "mantra of Potence",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel My Wrath"
-                } 
-              }}
-      > 
+      <Character
+        title="Heal Firebrand"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Harrier",
+            "Harrier",
+            "Harrier",
+            "Harrier",
+            "Harrier",
+            "Harrier",
+            "Harrier",
+            "Cleric",
+            "Harrier",
+            "Cleric",
+            "Cleric",
+            "Cleric",
+            "Harrier",
+            "Harrier"
+          ],
+          "attributes": {
+            "Health": 17145,
+            "Armor": 2787,
+            "Power": 3035,
+            "Precision": 1323,
+            "Toughness": 1516,
+            "Vitality": 1550,
+            "Ferocity": 300,
+            "Condition Damage": 1038,
+            "Expertise": 0,
+            "Concentration": 1121,
+            "Healing Power": 1712,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.9973,
+            "Critical Chance": 0.5038,
+            "Critical Damage": 1.7,
+            "Burning Duration": 1.05,
+            "Effective Power": 5901.431,
+            "Power DPS": 575.749,
+            "Burning Damage": 0,
+            "Burning Stacks": 0,
+            "Burning DPS": 0,
+            "Bleeding Damage": 0,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 0,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 0,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 0,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 575.749,
+            "Healing": 720.39
+          },
+          "runeId": 24842,
+          "runeName": "Monk",
+          "infusions": [
+            37125, 37125, 37125, 37125, 37125, 37125, 37125,
+            37125, 37125, 37125, 37125, 37125, 37125, 37125,
+            37125, 37125, 37125, 37125
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1": "transference",
+            "weapon1OffType": "Shield",
+            "weapon1OffSigil": "concentration",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "transference",
+            "weapon2MainSigil2": "concentration"
+          },
+          "consumables": {
+            "foodId": "91690",
+            "utility": "bountiful-maintenance-oil",
+            "infusion": "Healing +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility1": "mantra of Potence",
+            "utility3": "Sanctuary",
+            "elite": "Feel My Wrath"
+          }
+        }}
+      >
 
 
       Note that  this build variant is optimized for 150 agony resistance. If you have more Agony Resistance, feel free to swap out more Harrier pieces for Cleric but make sure you are maintaining 100% boon duration on both weapon sets. You can play full Harrier, however you will lose some <Attribute name="Healing Power"/>. Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!

--- a/builds/guardian/power-dragonhunter/index.md
+++ b/builds/guardian/power-dragonhunter/index.md
@@ -22,105 +22,98 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Guardian",
-                  "title":"222 Ar", "weight":"Heavy", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health":11645,
-                  "Armor":2514,
-                  "Power":3933,
-                  "Precision":2363,
-                  "Toughness":1243,
-                  "Vitality":1000,
-                  "Ferocity":1656,
-                  "Condition Damage":850,
-                  "Expertise":0,
-                  "Concentration":243,
-                  "Healing Power":0,
-                  "Agony Resistance":162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 1.622,
-                  "Critical Chance": 0.999047619047619,
-                  "Critical Damage": 2.604,
-                  "Effective Power":36090.11227985033,
-                  "Power DPS":46137.53283369391,
-                  "Burning Damage":377.703125,
-                  "Burning Stacks":1.85,
-                  "Burning DPS":698.75078125,
-                  "Bleeding Damage":104.9375,
-                  "Bleeding Stacks":0,
-                  "Bleeding DPS":0,
-                  "Poison Damage":121.46875,
-                  "Poison Stacks":0,
-                  "Poison DPS":0,
-                  "Torment Damage":155.68125,
-                  "Torment Stacks":0,
-                  "Torment DPS":0,
-                  "Confusion Damage":104.9375,
-                  "Confusion Stacks":0,
-                  "Confusion DPS":0,
-                  "Damage":46836.28361494391,
-                  "Effective Health":40253853.75,
-                  "Survivability":20464.592653787495,
-                  "Effective Healing":390,
-                  "Healing":390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType":"Sword",
-                  "weapon1MainSigil1":"Force",
-                  "weapon1OffType":"Focus",
-                  "weapon1OffSigil":"Impact",
-                  "weapon2MainType":"Greatsword",
-                  "weapon2MainSigil1":"Force",
-                  "weapon2MainSigil2":"Impact"
-              },
-                  "consumables": {
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-          
-              },
-                "skills": {
-                  "heal": "Litany of Wrath",
-                  "utility1": "Procession of Blades",
-                  "utility2": "Sword of Justice",
-                  "utility3": "Bane Signet",
-                  "elite": "Dragons Maw"
-                } 
-              }}
-      >  
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "title": "222 Ar",
+          "weight": "Heavy",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 11645,
+            "Armor": 2514,
+            "Power": 3933,
+            "Precision": 2363,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 1656,
+            "Condition Damage": 850,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 1.622,
+            "Critical Chance": 0.999047619047619,
+            "Critical Damage": 2.604,
+            "Effective Power": 36090.11227985033,
+            "Power DPS": 46137.53283369391,
+            "Burning Damage": 377.703125,
+            "Burning Stacks": 1.85,
+            "Burning DPS": 698.75078125,
+            "Bleeding Damage": 104.9375,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 121.46875,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 155.68125,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 104.9375,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 46836.28361494391,
+            "Effective Health": 40253853.75,
+            "Survivability": 20464.592653787495,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "Force",
+            "weapon1OffType": "Focus",
+            "weapon1OffSigil": "Impact",
+            "weapon2MainType": "Greatsword",
+            "weapon2MainSigil1": "Force",
+            "weapon2MainSigil2": "Impact"
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Litany of Wrath",
+            "utility1": "Procession of Blades",
+            "utility2": "Sword of Justice",
+            "utility3": "Bane Signet",
+            "elite": "Dragons Maw"
+          }
+        }}
+      >
 
 
       If you use <Trait name="Perfectinscriptions"/> you are lacking critical chance, therefore additional assassins pieces are required. You can of course mitigate this by increasing your <Attribute name="Agony Resistance"/>. You need at least  <Attribute name="Agony Resistance" text="203 Agony Resistance"/> to compensate the lacking <Attribute name="Precision"/>.   It is not recommended to run <Trait name="Righthandstrength"/> unless you have multiple <Specialization name="Guardian"/> or another source of <Boon name="Resolution"/>.   
@@ -128,109 +121,97 @@ sections:
 
       </Character>  
 
-      <Character title="203 Agony Resistance" gear={{
-        "profession": "Guardian",
-        "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 11645,
-          "Armor": 2575,
-          "Power": 3892,
-          "Precision": 2365,
-          "Toughness": 1304,
-          "Vitality": 1000,
-          "Ferocity": 1556,
-          "Condition Damage": 750,
-          "Expertise": 0,
-          "Concentration": 304,
-          "Healing Power": 0,
-          "Agony Resistance": 203,
-          "Condition Duration": 0,
-          "Boon Duration": 0.20266666666666666,
-          "Critical Chance": 1.00,
-          "Critical Damage": 2.5373333333333335,
-          "Effective Power": 34819.97973867529,
-          "Power DPS": 44513.797740624555,
-          "Burning Damage": 355.421875,
-          "Burning Stacks": 1.85,
-          "Burning DPS": 657.5304687500001,
-          "Bleeding Damage": 96.3125,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 112.84375,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 142.74375,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 96.3125,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 45171.32820937456,
-          "Effective Health": 54836668.90625001,
-          "Survivability": 27878.326846085412,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131
-        ],
-        "weight": "Heavy",
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Sword",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Focus",
-          "weapon1OffSigilId": 24868,
-          "weapon2MainType": "Greatsword",
-          "weapon2MainSigil1Id": 24615,
-          "weapon2MainSigil2Id": 24868
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-       },
-        "skills": {
-          "heal": "Litany of Wrath",
-          "utility1": "Procession of Blades",
-          "utility2": "Sword of Justice",
-          "utility3": "Bane Signet",
-          "elite": "Dragons Maw"
-        } 
-      }}>  
+      <Character
+        title="203 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 11645,
+            "Armor": 2575,
+            "Power": 3892,
+            "Precision": 2365,
+            "Toughness": 1304,
+            "Vitality": 1000,
+            "Ferocity": 1556,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 304,
+            "Healing Power": 0,
+            "Agony Resistance": 203,
+            "Condition Duration": 0,
+            "Boon Duration": 0.20266666666666666,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.5373333333333335,
+            "Effective Power": 34819.97973867529,
+            "Power DPS": 44513.797740624555,
+            "Burning Damage": 355.421875,
+            "Burning Stacks": 1.85,
+            "Burning DPS": 657.5304687500001,
+            "Bleeding Damage": 96.3125,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 112.84375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 142.74375,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 96.3125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 45171.32820937456,
+            "Effective Health": 54836668.90625001,
+            "Survivability": 27878.326846085412,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weight": "Heavy",
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Focus",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Greatsword",
+            "weapon2MainSigil1Id": 24615,
+            "weapon2MainSigil2Id": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Litany of Wrath",
+            "utility1": "Procession of Blades",
+            "utility2": "Sword of Justice",
+            "utility3": "Bane Signet",
+            "elite": "Dragons Maw"
+          }
+        }}
+      >
 
 
       It is not recommended to run <Trait name="Righthandstrength"/> unless you have multiple <Specialization name="Guardian"/> or another source of <Boon name="Resolution"/>. 

--- a/builds/guardian/power-firebrand/index.md
+++ b/builds/guardian/power-firebrand/index.md
@@ -26,103 +26,97 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance (24.6% BD)" 
-                 gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Assassin",
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 14145,
-                  "Armor": 2514,
-                  "Power": 3770,
-                  "Precision": 2365,
-                  "Toughness": 1243,
-                  "Vitality": 1250,
-                  "Ferocity": 1519,
-                  "Condition Damage": 1038,
-                  "Expertise": 0,
-                  "Concentration": 376,
-                  "Healing Power": 250,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.25066666666666666,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.5126666666666665,
-                  "Effective Power": 25146.327163648635,
-                  "Power DPS": 32824.81674423137,
-                  "Burning Damage": 419.59187499999996,
-                  "Burning Stacks": 1.1,
-                  "Burning DPS": 461.5510625,
-                  "Bleeding Damage": 121.1525,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 137.68375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 180.00375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 121.1525,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 33286.367806731374,
-                  "Effective Health": 65031319.23750001,
-                  "Survivability": 33061.16890569396,
-                  "Effective Healing": 465,
-                  "Healing": 465
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1Id": 24615,
-                  "weapon1OffType": "Focus",
-                  "weapon1OffSigilId": 24868,
-                  "weapon2MainType": "Greatsword",
-                  "weapon2MainSigil1Id": 24615,
-                  "weapon2MainSigil2Id": 24868
-              }, "consumables":{
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility1": "Mantra of Potence",
-                  "utility2": "Sword of Justice",
-                  "utility3": "Bane Signet",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      >  
+      <Character
+        title="162 Agony Resistance (24.6% BD)"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Assassin",
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 14145,
+            "Armor": 2514,
+            "Power": 3770,
+            "Precision": 2365,
+            "Toughness": 1243,
+            "Vitality": 1250,
+            "Ferocity": 1519,
+            "Condition Damage": 1038,
+            "Expertise": 0,
+            "Concentration": 376,
+            "Healing Power": 250,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.25066666666666666,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.5126666666666665,
+            "Effective Power": 25146.327163648635,
+            "Power DPS": 32824.81674423137,
+            "Burning Damage": 419.59187499999996,
+            "Burning Stacks": 1.1,
+            "Burning DPS": 461.5510625,
+            "Bleeding Damage": 121.1525,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 137.68375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 180.00375,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 121.1525,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 33286.367806731374,
+            "Effective Health": 65031319.23750001,
+            "Survivability": 33061.16890569396,
+            "Effective Healing": 465,
+            "Healing": 465
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Focus",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Greatsword",
+            "weapon2MainSigil1Id": 24615,
+            "weapon2MainSigil2Id": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility1": "Mantra of Potence",
+            "utility2": "Sword of Justice",
+            "utility3": "Bane Signet",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       Note that this build variant only gains boon duration from the <Item id="79722"/>.
@@ -137,103 +131,97 @@ sections:
 
       </Character>  
 
-      <Character title="222 Agony Resistance (24.6% BD)" 
-                 gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 14145,
-                  "Armor": 2604,
-                  "Power": 3885,
-                  "Precision": 2382,
-                  "Toughness": 1333,
-                  "Vitality": 1250,
-                  "Ferocity": 1544,
-                  "Condition Damage": 1038,
-                  "Expertise": 0,
-                  "Concentration": 373,
-                  "Healing Power": 250,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.24866666666666667,
-                  "Critical Chance": 1.0080952380952381,
-                  "Critical Damage": 2.5293333333333334,
-                  "Effective Power": 26085.275244209894,
-                  "Power DPS": 34050.47480857588,
-                  "Burning Damage": 419.59187499999996,
-                  "Burning Stacks": 1.1,
-                  "Burning DPS": 461.5510625,
-                  "Bleeding Damage": 121.1525,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 137.68375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 180.00375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 121.1525,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 34512.02587107588,
-                  "Effective Health": 50646172.5,
-                  "Survivability": 25747.927046263347,
-                  "Effective Healing": 465,
-                  "Healing": 465
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1Id": 24615,
-                  "weapon1OffType": "Focus",
-                  "weapon1OffSigilId": 24868,
-                  "weapon2MainType": "Greatsword",
-                  "weapon2MainSigil1Id": 24615,
-                  "weapon2MainSigil2Id": 24868
-              }, "consumables":{
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility1": "Mantra of Potence",
-                  "utility2": "Sword of Justice",
-                  "utility3": "Bane Signet",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      >  
+      <Character
+        title="222 Agony Resistance (24.6% BD)"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 14145,
+            "Armor": 2604,
+            "Power": 3885,
+            "Precision": 2382,
+            "Toughness": 1333,
+            "Vitality": 1250,
+            "Ferocity": 1544,
+            "Condition Damage": 1038,
+            "Expertise": 0,
+            "Concentration": 373,
+            "Healing Power": 250,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.24866666666666667,
+            "Critical Chance": 1.0080952380952381,
+            "Critical Damage": 2.5293333333333334,
+            "Effective Power": 26085.275244209894,
+            "Power DPS": 34050.47480857588,
+            "Burning Damage": 419.59187499999996,
+            "Burning Stacks": 1.1,
+            "Burning DPS": 461.5510625,
+            "Bleeding Damage": 121.1525,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 137.68375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 180.00375,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 121.1525,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 34512.02587107588,
+            "Effective Health": 50646172.5,
+            "Survivability": 25747.927046263347,
+            "Effective Healing": 465,
+            "Healing": 465
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Focus",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Greatsword",
+            "weapon2MainSigil1Id": 24615,
+            "weapon2MainSigil2Id": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility1": "Mantra of Potence",
+            "utility2": "Sword of Justice",
+            "utility3": "Bane Signet",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       Note that this build variant only gains boon duration from the <Item id="79722"/>.

--- a/builds/guardian/seraph-firebrand/index.md
+++ b/builds/guardian/seraph-firebrand/index.md
@@ -23,103 +23,97 @@ sections:
     content: >-
       <CharacterWithAr> 
 
-      <Character title="Celestial 162 Agony Resistance" 
-                 gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial"
-              ], "attributes":{
-                   "Health": 23895,
-                   "Armor": 3189,
-                   "Power": 2465,
-                   "Precision": 1998,
-                   "Toughness": 1918,
-                   "Vitality": 2225,
-                   "Ferocity": 975,
-                   "Condition Damage": 2139,
-                   "Expertise": 745,
-                   "Concentration": 918,
-                   "Healing Power": 925,
-                   "Agony Resistance": 162,
-                   "Condition Duration": 0.59666666666666664,
-                   "Boon Duration": 0.762,
-                   "Critical Chance": 0.8252380952380952,
-                   "Critical Damage": 2.15,
-                   "Burning Duration": 0.40,
-                   "Effective Power": 6906.244055059524,
-                   "Power DPS": 5962.186819962823,
-                   "Burning Damage": 796.0184999999999,
-                   "Burning Stacks": 24.359333333333332,
-                   "Burning DPS": 19390.479980999997,
-                   "Bleeding Damage": 224.88000000000002,
-                   "Bleeding Stacks": 5.907666666666667,
-                   "Bleeding DPS": 1328.51608,
-                   "Poison Damage": 242.13000000000002,
-                   "Poison Stacks": 0,
-                   "Poison DPS": 0,
-                   "Torment Damage": 335.52,
-                   "Torment Stacks": 0,
-                   "Torment DPS": 0,
-                   "Confusion Damage": 224.88000000000002,
-                   "Confusion Stacks": 0,
-                   "Confusion DPS": 0,
-                   "Damage": 26681.18288096282,
-                   "Effective Health": 126684420.1875,
-                   "Survivability": 64404.89079181495,
-                   "Effective Healing": 734.2500000000001,
-                   "Healing": 734.2500000000001
-              }, "runeId":24691, "runeName":"Traveler", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1Id": 44944,
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigilId": 24624,
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1Id": 74326,
-                  "weapon2MainSigil2Id": 24624
-              }, "consumables":{
-                   "foodId": 91703,
-                   "utilityId": 77567,
-                   "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility2": "Mantra of Potence",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      > 
+      <Character
+        title="Celestial 162 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial"
+          ],
+          "attributes": {
+            "Health": 23895,
+            "Armor": 3189,
+            "Power": 2465,
+            "Precision": 1998,
+            "Toughness": 1918,
+            "Vitality": 2225,
+            "Ferocity": 975,
+            "Condition Damage": 2139,
+            "Expertise": 745,
+            "Concentration": 918,
+            "Healing Power": 925,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.59666666666666664,
+            "Boon Duration": 0.762,
+            "Critical Chance": 0.8252380952380952,
+            "Critical Damage": 2.15,
+            "Burning Duration": 0.4,
+            "Effective Power": 6906.244055059524,
+            "Power DPS": 5962.186819962823,
+            "Burning Damage": 796.0184999999999,
+            "Burning Stacks": 24.359333333333332,
+            "Burning DPS": 19390.479980999997,
+            "Bleeding Damage": 224.88000000000002,
+            "Bleeding Stacks": 5.907666666666667,
+            "Bleeding DPS": 1328.51608,
+            "Poison Damage": 242.13000000000002,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 335.52,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 224.88000000000002,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 26681.18288096282,
+            "Effective Health": 126684420.1875,
+            "Survivability": 64404.89079181495,
+            "Effective Healing": 734.2500000000001,
+            "Healing": 734.2500000000001
+          },
+          "runeId": 24691,
+          "runeName": "Traveler",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 44944,
+            "weapon1OffType": "Torch",
+            "weapon1OffSigilId": 24624,
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1Id": 74326,
+            "weapon2MainSigil2Id": 24624
+          },
+          "consumables": {
+            "foodId": 91703,
+            "utilityId": 77567,
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility2": "Mantra of Potence",
+            "utility3": "Sanctuary",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       **This build deals less damage than the seraph version, but gains more boon duration which allows it to be played with lower Agony Resistance (typically you want a minimum of 60% to play <Trait name="Legendary Lore"/>). This build also has the advantage of working in other content such as Raids and Strike Missions**
@@ -130,103 +124,97 @@ sections:
 
       </Character>
 
-      <Character title="Celestial 203 Agony Resistance"
-                  gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Celestial",
-                  "Seraph",
-                  "Celestial",
-                  "Celestial"
-              ], "attributes":{
-                  "Health": 20895,
-                  "Armor": 2950,
-                  "Power": 2165,
-                  "Precision": 2248,
-                  "Toughness": 1679,
-                  "Vitality": 1925,
-                  "Ferocity": 675,
-                  "Condition Damage": 2548,
-                  "Expertise": 445,
-                  "Concentration": 938,
-                  "Healing Power": 884,
-                  "Agony Resistance": 203,
-                  "Condition Duration": 0.29666666666666668,
-                  "Boon Duration": 0.6253333333333333,
-                  "Critical Chance": 0.9442857142857143,
-                  "Critical Damage": 1.95,
-                  "Burning Duration": 0.70,
-                  "Effective Power": 5904.0419866071425,
-                  "Power DPS": 5096.981953782523,
-                  "Burning Damage": 907.2465,
-                  "Burning Stacks": 24.359333333333332,
-                  "Burning DPS": 22099.919908999997,
-                  "Bleeding Damage": 262.32,
-                  "Bleeding Stacks": 4.797666666666667,
-                  "Bleeding DPS": 1258.52392,
-                  "Poison Damage": 279.57,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 391.68,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 262.32,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 28455.42578278252,
-                  "Effective Health": 112724607.18750001,
-                  "Survivability": 57307.88367437723,
-                  "Effective Healing": 720.7200000000001,
-                  "Healing": 720.7200000000001
-              }, "runeId":24765, "runeName":"Balthazar", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1Id": 44944,
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigilId": 24560,
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1Id": 74326,
-                  "weapon2MainSigil2Id": 44944
-              }, "consumables":{
-                   "foodId": 91703,
-                   "utilityId": 48917,
-                   "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility2": "Mantra of Potence",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      > 
+      <Character
+        title="Celestial 203 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Celestial",
+            "Seraph",
+            "Celestial",
+            "Celestial"
+          ],
+          "attributes": {
+            "Health": 20895,
+            "Armor": 2950,
+            "Power": 2165,
+            "Precision": 2248,
+            "Toughness": 1679,
+            "Vitality": 1925,
+            "Ferocity": 675,
+            "Condition Damage": 2548,
+            "Expertise": 445,
+            "Concentration": 938,
+            "Healing Power": 884,
+            "Agony Resistance": 203,
+            "Condition Duration": 0.29666666666666668,
+            "Boon Duration": 0.6253333333333333,
+            "Critical Chance": 0.9442857142857143,
+            "Critical Damage": 1.95,
+            "Burning Duration": 0.7,
+            "Effective Power": 5904.0419866071425,
+            "Power DPS": 5096.981953782523,
+            "Burning Damage": 907.2465,
+            "Burning Stacks": 24.359333333333332,
+            "Burning DPS": 22099.919908999997,
+            "Bleeding Damage": 262.32,
+            "Bleeding Stacks": 4.797666666666667,
+            "Bleeding DPS": 1258.52392,
+            "Poison Damage": 279.57,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 391.68,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 262.32,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 28455.42578278252,
+            "Effective Health": 112724607.18750001,
+            "Survivability": 57307.88367437723,
+            "Effective Healing": 720.7200000000001,
+            "Healing": 720.7200000000001
+          },
+          "runeId": 24765,
+          "runeName": "Balthazar",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 44944,
+            "weapon1OffType": "Torch",
+            "weapon1OffSigilId": 24560,
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1Id": 74326,
+            "weapon2MainSigil2Id": 44944
+          },
+          "consumables": {
+            "foodId": 91703,
+            "utilityId": 48917,
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility2": "Mantra of Potence",
+            "utility3": "Sanctuary",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       **This is an option for a Celestial build with high Agony Resistance. It deals slightly less damage then the Seraph variant, but has the advantage of some extra survivability with extra <Attribute name="Vitality"/> and <Attribute name="Toughness"/>.**  
@@ -236,103 +224,97 @@ sections:
               
       </Character>  
 
-      <Character title="Seraph 203 Agony Resistance"
-                  gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph",
-                  "Celestial",
-                  "Seraph",
-                  "Seraph",
-                  "Seraph"
-              ], "attributes":{
-                  "Health": 17645,
-                  "Armor": 2625,
-                  "Power": 1840,
-                  "Precision": 2515,
-                  "Toughness": 1354,
-                  "Vitality": 1600,
-                  "Ferocity": 350,
-                  "Condition Damage": 2854,
-                  "Expertise": 120,
-                  "Concentration": 938,
-                  "Healing Power": 884,
-                  "Agony Resistance": 203,
-                  "Condition Duration": 0.08,
-                  "Boon Duration": 0.6253333333333333,
-                  "Critical Chance": 1.0714285714285714,
-                  "Critical Damage": 1.7333333333333334,
-                  "Burning Duration": 0.90,
-                  "Effective Power": 4584.666666666667,
-                  "Power DPS": 3957.960210499294,
-                  "Burning Damage": 989.06325,
-                  "Burning Stacks": 24.156,
-                  "Burning DPS": 23891.811867,
-                  "Bleeding Damage": 289.85999999999996,
-                  "Bleeding Stacks": 3.9960000000000004,
-                  "Bleeding DPS": 1158.28056,
-                  "Poison Damage": 307.10999999999996,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 432.99,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 289.85999999999996,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 29008.052637499295,
-                  "Effective Health": 84704271.09375001,
-                  "Survivability": 43062.66959519574,
-                  "Effective Healing": 720.7200000000001,
-                  "Healing": 720.7200000000001
-              }, "runeId":24765, "runeName":"Balthazar", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1Id": 44944,
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigilId": 24624,
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1Id": 74326,
-                  "weapon2MainSigil2Id": 24624
-              }, "consumables":{
-                   "foodId": 91703,
-                   "utilityId": 48917,
-                   "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility2": "Mantra of Potence",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
-      > 
+      <Character
+        title="Seraph 203 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Seraph",
+            "Celestial",
+            "Seraph",
+            "Seraph",
+            "Seraph"
+          ],
+          "attributes": {
+            "Health": 17645,
+            "Armor": 2625,
+            "Power": 1840,
+            "Precision": 2515,
+            "Toughness": 1354,
+            "Vitality": 1600,
+            "Ferocity": 350,
+            "Condition Damage": 2854,
+            "Expertise": 120,
+            "Concentration": 938,
+            "Healing Power": 884,
+            "Agony Resistance": 203,
+            "Condition Duration": 0.08,
+            "Boon Duration": 0.6253333333333333,
+            "Critical Chance": 1.0714285714285714,
+            "Critical Damage": 1.7333333333333334,
+            "Burning Duration": 0.9,
+            "Effective Power": 4584.666666666667,
+            "Power DPS": 3957.960210499294,
+            "Burning Damage": 989.06325,
+            "Burning Stacks": 24.156,
+            "Burning DPS": 23891.811867,
+            "Bleeding Damage": 289.85999999999996,
+            "Bleeding Stacks": 3.9960000000000004,
+            "Bleeding DPS": 1158.28056,
+            "Poison Damage": 307.10999999999996,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 432.99,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 289.85999999999996,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 29008.052637499295,
+            "Effective Health": 84704271.09375001,
+            "Survivability": 43062.66959519574,
+            "Effective Healing": 720.7200000000001,
+            "Healing": 720.7200000000001
+          },
+          "runeId": 24765,
+          "runeName": "Balthazar",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 44944,
+            "weapon1OffType": "Torch",
+            "weapon1OffSigilId": 24624,
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1Id": 74326,
+            "weapon2MainSigil2Id": 24624
+          },
+          "consumables": {
+            "foodId": 91703,
+            "utilityId": 48917,
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility2": "Mantra of Potence",
+            "utility3": "Sanctuary",
+            "elite": "Feel my Wrath"
+          }
+        }}
+      >
 
 
       **This is the standard build variant for high Agony Resistance. It provides higher damage then the Celestial build in fractals whilst still providing more than enough support for most groups.**
@@ -342,102 +324,96 @@ sections:
               
       </Character>  
 
-      <Character title="Celestial Heal 162 Agony Resistance"
-                  gear={{ "profession": "Guardian",
-                  "weight":"Heavy", "gear":[
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial"
-              ], "attributes":{
-                  "Health": 20535,
-                  "Armor": 3153,
-                  "Power": 2429,
-                  "Precision": 1962,
-                  "Toughness": 1882,
-                  "Vitality": 1889,
-                  "Ferocity": 939,
-                  "Condition Damage": 1907,
-                  "Expertise": 739,
-                  "Concentration": 882,
-                  "Healing Power": 1064,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.59266666666666666,
-                  "Boon Duration": 0.738,
-                  "Critical Chance": 0.8080952380952381,
-                  "Critical Damage": 2.126,
-                  "Burning Duration": 0.40,
-                  "Effective Power": 6668.827162916666,
-                  "Power DPS": 5757.223911921125,
-                  "Burning Damage": 705.198328125,
-                  "Burning Stacks": 24.310533333333332,
-                  "Burning DPS": 17143.74746249375,
-                  "Bleeding Damage": 196.10375000000002,
-                  "Bleeding Stacks": 5.892866666666667,
-                  "Bleeding DPS": 1155.6132515833335,
-                  "Poison Damage": 212.63500000000002,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 292.430625,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 196.10375000000002,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 24056.58462599821,
-                  "Effective Health": 107641646.4375,
-                  "Survivability": 54723.76534697509,
-                  "Effective Healing": 851.0400000000001,
-                  "Healing": 851.0400000000001
-              }, "runeId":24842, "runeName":"Monk", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Axe",
-                  "weapon1MainSigil1": "Malice",
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigil": "smoldering",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "transference",
-                  "weapon2MainSigil2": "smoldering"
-              }, "consumables":{
-                  "foodId": 91727,
-                  "utilityId": 77567,
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Mantra of Solace",
-                  "utility2": "Mantra of Potence",
-                  "utility3": "Sanctuary",
-                  "elite": "Feel my Wrath"
-                } 
-              }}
+      <Character
+        title="Celestial Heal 162 Agony Resistance"
+        gear={{
+          "profession": "Guardian",
+          "weight": "Heavy",
+          "gear": [
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial"
+          ],
+          "attributes": {
+            "Health": 20535,
+            "Armor": 3153,
+            "Power": 2429,
+            "Precision": 1962,
+            "Toughness": 1882,
+            "Vitality": 1889,
+            "Ferocity": 939,
+            "Condition Damage": 1907,
+            "Expertise": 739,
+            "Concentration": 882,
+            "Healing Power": 1064,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.59266666666666666,
+            "Boon Duration": 0.738,
+            "Critical Chance": 0.8080952380952381,
+            "Critical Damage": 2.126,
+            "Burning Duration": 0.4,
+            "Effective Power": 6668.827162916666,
+            "Power DPS": 5757.223911921125,
+            "Burning Damage": 705.198328125,
+            "Burning Stacks": 24.310533333333332,
+            "Burning DPS": 17143.74746249375,
+            "Bleeding Damage": 196.10375000000002,
+            "Bleeding Stacks": 5.892866666666667,
+            "Bleeding DPS": 1155.6132515833335,
+            "Poison Damage": 212.63500000000002,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 292.430625,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 196.10375000000002,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 24056.58462599821,
+            "Effective Health": 107641646.4375,
+            "Survivability": 54723.76534697509,
+            "Effective Healing": 851.0400000000001,
+            "Healing": 851.0400000000001
+          },
+          "runeId": 24842,
+          "runeName": "Monk",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1": "Malice",
+            "weapon1OffType": "Torch",
+            "weapon1OffSigil": "smoldering",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "transference",
+            "weapon2MainSigil2": "smoldering"
+          },
+          "consumables": {
+            "foodId": 91727,
+            "utilityId": 77567,
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mantra of Solace",
+            "utility2": "Mantra of Potence",
+            "utility3": "Sanctuary",
+            "elite": "Feel my Wrath"
+          }
+        }}
       >
 
 

--- a/builds/mesmer/power-chronomancer/index.md
+++ b/builds/mesmer/power-chronomancer/index.md
@@ -28,102 +28,95 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character gear={{ "profession": "Mesmer",
-                  "weight":"Light", "gear":[
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin"
-                ],
-                "attributes": {
-                  "Health": 15922,
-                  "Armor": 2210,
-                  "Power": 3225,
-                  "Precision": 2575,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 1556,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.5373333333333335,
-                  "Effective Power": 28053.276783011115,
-                  "Power DPS": 41664.03101735613,
-                  "Burning Damage": 355.421875,
-                  "Burning Stacks": 0.63,
-                  "Burning DPS": 223.91578125,
-                  "Bleeding Damage": 96.3125,
-                  "Bleeding Stacks": 24,
-                  "Bleeding DPS": 2311.5,
-                  "Poison Damage": 112.84375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 142.74375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 96.3125,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 44199.44679860613,
-                  "Effective Health": 64349360.07500001,
-                  "Survivability": 32714.468772242,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1Id": 24615,
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigilId": 24868,
-                  "weapon2OffType": "Focus",
-                  "weapon2OffSigilId": 24868
-              }, "consumables":{
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of the Ether",
-                  "utility1": "Mantra of Pain",
-                  "utility2": "Phantasmal Disenchanter",
-                  "utility3": "MIrror Images",
-                  "elite": "Signet of Humility"
-                } 
-              }}
-      >  
+      <Character
+          gear={{
+            "profession": "Mesmer",
+            "weight": "Light",
+            "gear": [
+              "Berserker",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Assassin",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Assassin"
+            ],
+            "attributes": {
+              "Health": 15922,
+              "Armor": 2210,
+              "Power": 3225,
+              "Precision": 2575,
+              "Toughness": 1243,
+              "Vitality": 1000,
+              "Ferocity": 1556,
+              "Condition Damage": 750,
+              "Expertise": 0,
+              "Concentration": 243,
+              "Healing Power": 0,
+              "Agony Resistance": 162,
+              "Condition Duration": 0,
+              "Boon Duration": 0.162,
+              "Critical Chance": 1.0,
+              "Critical Damage": 2.5373333333333335,
+              "Effective Power": 28053.276783011115,
+              "Power DPS": 41664.03101735613,
+              "Burning Damage": 355.421875,
+              "Burning Stacks": 0.63,
+              "Burning DPS": 223.91578125,
+              "Bleeding Damage": 96.3125,
+              "Bleeding Stacks": 24,
+              "Bleeding DPS": 2311.5,
+              "Poison Damage": 112.84375,
+              "Poison Stacks": 0,
+              "Poison DPS": 0,
+              "Torment Damage": 142.74375,
+              "Torment Stacks": 0,
+              "Torment DPS": 0,
+              "Confusion Damage": 96.3125,
+              "Confusion Stacks": 0,
+              "Confusion DPS": 0,
+              "Damage": 44199.44679860613,
+              "Effective Health": 64349360.07500001,
+              "Survivability": 32714.468772242,
+              "Effective Healing": 390,
+              "Healing": 390
+            },
+            "runeId": 24836,
+            "runeName": "Scholar",
+            "infusions": [
+              37131, 37131, 37131, 37131, 37131, 37131, 37131,
+              37131, 37131, 37131, 37131, 37131, 37131, 37131,
+              37131, 37131, 37131, 37131
+            ],
+            "weapons": {
+              "weapon1MainType": "Sword",
+              "weapon1MainSigil1Id": 24615,
+              "weapon1OffType": "Sword",
+              "weapon1OffSigilId": 24868,
+              "weapon2OffType": "Focus",
+              "weapon2OffSigilId": 24868
+            },
+            "consumables": {
+              "foodId": 91805,
+              "utilityId": 9443,
+              "infusion": "Mighty +9 Agony Infusion"
+            },
+            "skills": {
+              "heal": "Signet of the Ether",
+              "utility1": "Mantra of Pain",
+              "utility2": "Phantasmal Disenchanter",
+              "utility3": "MIrror Images",
+              "elite": "Signet of Humility"
+            }
+          }}
+        >
 
 
       Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!
@@ -138,102 +131,95 @@ sections:
 
       </Character>  
 
-      <Character gear={{ "profession": "Mesmer",
-                  "weight":"Light", "gear":[
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin",
-                  "Assassin"
-                ],
-                "attributes": {
-                  "Health": 15922,
-                  "Armor": 2285,
-                  "Power": 3300,
-                  "Precision": 2575,
-                  "Toughness": 1318,
-                  "Vitality": 1000,
-                  "Ferocity": 1556,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 318,
-                  "Healing Power": 0,
-                  "Agony Resistance": 212,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.212,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.5373333333333335,
-                  "Effective Power": 28705.678568662537,
-                  "Power DPS": 42632.961971248136,
-                  "Burning Damage": 355.421875,
-                  "Burning Stacks": 0.63,
-                  "Burning DPS": 223.91578125,
-                  "Bleeding Damage": 96.3125,
-                  "Bleeding Stacks": 24,
-                  "Bleeding DPS": 2311.5,
-                  "Poison Damage": 112.84375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 142.74375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 96.3125,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 45168.377752498134,
-                  "Effective Health": 66533161.88750001,
-                  "Survivability": 33824.68830071175,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1Id": 24615,
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigilId": 24868,
-                  "weapon2OffType": "Focus",
-                  "weapon2OffSigilId": 24868
-              }, "consumables":{
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of the Ether",
-                  "utility1": "Mantra of Pain",
-                  "utility2": "Phantasmal Disenchanter",
-                  "utility3": "MIrror Images",
-                  "elite": "Signet of Humility"
-                } 
-              }}
-      >  
+      <Character
+        gear={{
+          "profession": "Mesmer",
+          "weight": "Light",
+          "gear": [
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Assassin",
+            "Assassin"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2285,
+            "Power": 3300,
+            "Precision": 2575,
+            "Toughness": 1318,
+            "Vitality": 1000,
+            "Ferocity": 1556,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 318,
+            "Healing Power": 0,
+            "Agony Resistance": 212,
+            "Condition Duration": 0,
+            "Boon Duration": 0.212,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.5373333333333335,
+            "Effective Power": 28705.678568662537,
+            "Power DPS": 42632.961971248136,
+            "Burning Damage": 355.421875,
+            "Burning Stacks": 0.63,
+            "Burning DPS": 223.91578125,
+            "Bleeding Damage": 96.3125,
+            "Bleeding Stacks": 24,
+            "Bleeding DPS": 2311.5,
+            "Poison Damage": 112.84375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 142.74375,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 96.3125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 45168.377752498134,
+            "Effective Health": 66533161.88750001,
+            "Survivability": 33824.68830071175,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Sword",
+            "weapon1OffSigilId": 24868,
+            "weapon2OffType": "Focus",
+            "weapon2OffSigilId": 24868
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Signet of the Ether",
+            "utility1": "Mantra of Pain",
+            "utility2": "Phantasmal Disenchanter",
+            "utility3": "MIrror Images",
+            "elite": "Signet of Humility"
+          }
+        }}
+      >
 
 
       If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>.
@@ -244,102 +230,95 @@ sections:
 
       </Character>  
 
-      <Character gear={{ "profession": "Mesmer",
-                  "weight":"Light", "gear":[
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin"
-                ],
-                "attributes": {
-                  "Health": 15922,
-                  "Armor": 2300,
-                  "Power": 3315,
-                  "Precision": 2575,
-                  "Toughness": 1333,
-                  "Vitality": 1000,
-                  "Ferocity": 1556,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 333,
-                  "Healing Power": 0,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.222,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.5373333333333335,
-                  "Effective Power": 28836.158925792817,
-                  "Power DPS": 42826.74816202653,
-                  "Burning Damage": 355.421875,
-                  "Burning Stacks": 0.63,
-                  "Burning DPS": 223.91578125,
-                  "Bleeding Damage": 96.3125,
-                  "Bleeding Stacks": 24,
-                  "Bleeding DPS": 2311.5,
-                  "Poison Damage": 112.84375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 142.74375,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 96.3125,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 45362.16394327653,
-                  "Effective Health": 66969922.250000015,
-                  "Survivability": 34046.7322064057,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1Id": 24615,
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigilId": 24868,
-                  "weapon2OffType": "Focus",
-                  "weapon2OffSigilId": 24868
-              }, "consumables":{
-                  "foodId": 91805,
-                  "utilityId": 9443,
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of the Ether",
-                  "utility1": "Mantra of Pain",
-                  "utility2": "Phantasmal Disenchanter",
-                  "utility3": "MIrror Images",
-                  "elite": "Signet of Humility"
-                } 
-              }}
-      >  
+      <Character
+          gear={{
+            "profession": "Mesmer",
+            "weight": "Light",
+            "gear": [
+              "Berserker",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Berserker",
+              "Berserker",
+              "Berserker",
+              "Assassin",
+              "Assassin",
+              "Berserker",
+              "Assassin",
+              "Assassin"
+            ],
+            "attributes": {
+              "Health": 15922,
+              "Armor": 2300,
+              "Power": 3315,
+              "Precision": 2575,
+              "Toughness": 1333,
+              "Vitality": 1000,
+              "Ferocity": 1556,
+              "Condition Damage": 750,
+              "Expertise": 0,
+              "Concentration": 333,
+              "Healing Power": 0,
+              "Agony Resistance": 222,
+              "Condition Duration": 0,
+              "Boon Duration": 0.222,
+              "Critical Chance": 1.0,
+              "Critical Damage": 2.5373333333333335,
+              "Effective Power": 28836.158925792817,
+              "Power DPS": 42826.74816202653,
+              "Burning Damage": 355.421875,
+              "Burning Stacks": 0.63,
+              "Burning DPS": 223.91578125,
+              "Bleeding Damage": 96.3125,
+              "Bleeding Stacks": 24,
+              "Bleeding DPS": 2311.5,
+              "Poison Damage": 112.84375,
+              "Poison Stacks": 0,
+              "Poison DPS": 0,
+              "Torment Damage": 142.74375,
+              "Torment Stacks": 0,
+              "Torment DPS": 0,
+              "Confusion Damage": 96.3125,
+              "Confusion Stacks": 0,
+              "Confusion DPS": 0,
+              "Damage": 45362.16394327653,
+              "Effective Health": 66969922.250000015,
+              "Survivability": 34046.7322064057,
+              "Effective Healing": 390,
+              "Healing": 390
+            },
+            "runeId": 24836,
+            "runeName": "Scholar",
+            "infusions": [
+              37131, 37131, 37131, 37131, 37131, 37131, 37131,
+              37131, 37131, 37131, 37131, 37131, 37131, 37131,
+              37131, 37131, 37131, 37131
+            ],
+            "weapons": {
+              "weapon1MainType": "Sword",
+              "weapon1MainSigil1Id": 24615,
+              "weapon1OffType": "Sword",
+              "weapon1OffSigilId": 24868,
+              "weapon2OffType": "Focus",
+              "weapon2OffSigilId": 24868
+            },
+            "consumables": {
+              "foodId": 91805,
+              "utilityId": 9443,
+              "infusion": "Mighty +9 Agony Infusion"
+            },
+            "skills": {
+              "heal": "Signet of the Ether",
+              "utility1": "Mantra of Pain",
+              "utility2": "Phantasmal Disenchanter",
+              "utility3": "MIrror Images",
+              "elite": "Signet of Humility"
+            }
+          }}
+        >
 
 
       If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>.

--- a/builds/necromancer/condi-scourge/index.md
+++ b/builds/necromancer/condi-scourge/index.md
@@ -35,104 +35,98 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Necromancer",
-                  "weight":"Light", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 19212,
-                  "Armor": 2210,
-                  "Power": 2923,
-                  "Precision": 2056,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 150,
-                  "Condition Damage": 3083,
-                  "Expertise": 1036,
-                  "Concentration": 468,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.8906666666666666,
-                  "Boon Duration": 0.312,
-                  "Critical Chance": 0.9528571428571428,
-                  "Critical Damage": 1.60,
-                  "Bleeding Duration": 0.20,
-                  "Effective Power": 7264.453605357142,
-                  "Power DPS": 3930.133737207079,
-                  "Burning Damage": 989.405625,
-                  "Burning Stacks": 6.428266666666667,
-                  "Burning DPS": 6360.163199,
-                  "Bleeding Damage": 336.3425,
-                  "Bleeding Stacks": 41.2,
-                  "Bleeding DPS": 13857.311,
-                  "Poison Damage": 355.03,
-                  "Poison Stacks": 6.995466666666667,
-                  "Poison DPS": 2483.6005306666666,
-                  "Torment Damage": 628.2046875,
-                  "Torment Stacks": 26.847466666666666,
-                  "Torment DPS": 16865.704407499998,
-                  "Confusion Damage": 336.3425,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 43496.912874373746,
-                  "Effective Health": 53073150,
-                  "Survivability": 26981.77427554652,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24848, "runeName":"Nightmare", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Scepter",
-                  "weapon1MainSigil1": "bursting",
-                  "weapon1OffType": "Torch",
-                  "weapon1OffSigil": "torment",
-                  "weapon2MainType": "Scepter",
-                  "weapon2MainSigil1": "bursting",
-                  "weapon2OffType": "Warhorn",
-                  "weapon2OffSigil": "torment"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-focusing-crystal",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of Vampirism",
-                  "utility2": "Blood is Power",
-                  "utility3": "Signet of Undeath",
-                  "elite": "Plaguelands"
-                } 
-              }}
-      >  
+      <Character
+          title="162 Agony Resistance"
+          gear={{
+            "profession": "Necromancer",
+            "weight": "Light",
+            "gear": [
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper",
+              "Viper"
+            ],
+            "attributes": {
+              "Health": 19212,
+              "Armor": 2210,
+              "Power": 2923,
+              "Precision": 2056,
+              "Toughness": 1243,
+              "Vitality": 1000,
+              "Ferocity": 150,
+              "Condition Damage": 3083,
+              "Expertise": 1036,
+              "Concentration": 468,
+              "Healing Power": 0,
+              "Agony Resistance": 162,
+              "Condition Duration": 0.8906666666666666,
+              "Boon Duration": 0.312,
+              "Critical Chance": 0.9528571428571428,
+              "Critical Damage": 1.6,
+              "Bleeding Duration": 0.2,
+              "Effective Power": 7264.453605357142,
+              "Power DPS": 3930.133737207079,
+              "Burning Damage": 989.405625,
+              "Burning Stacks": 6.428266666666667,
+              "Burning DPS": 6360.163199,
+              "Bleeding Damage": 336.3425,
+              "Bleeding Stacks": 41.2,
+              "Bleeding DPS": 13857.311,
+              "Poison Damage": 355.03,
+              "Poison Stacks": 6.995466666666667,
+              "Poison DPS": 2483.6005306666666,
+              "Torment Damage": 628.2046875,
+              "Torment Stacks": 26.847466666666666,
+              "Torment DPS": 16865.704407499998,
+              "Confusion Damage": 336.3425,
+              "Confusion Stacks": 0,
+              "Confusion DPS": 0,
+              "Damage": 43496.912874373746,
+              "Effective Health": 53073150,
+              "Survivability": 26981.77427554652,
+              "Effective Healing": 390,
+              "Healing": 390
+            },
+            "runeId": 24848,
+            "runeName": "Nightmare",
+            "infusions": [
+              37130, 37130, 37130, 37130, 37130, 37130, 37130,
+              37130, 37130, 37130, 37130, 37130, 37130, 37130,
+              37130, 37130, 37130, 37130
+            ],
+            "weapons": {
+              "weapon1MainType": "Scepter",
+              "weapon1MainSigil1": "bursting",
+              "weapon1OffType": "Torch",
+              "weapon1OffSigil": "torment",
+              "weapon2MainType": "Scepter",
+              "weapon2MainSigil1": "bursting",
+              "weapon2OffType": "Warhorn",
+              "weapon2OffSigil": "torment"
+            },
+            "consumables": {
+              "foodId": "91878",
+              "utility": "toxic-focusing-crystal",
+              "infusion": "Malign +9 Agony Infusion"
+            },
+            "skills": {
+              "heal": "Signet of Vampirism",
+              "utility2": "Blood is Power",
+              "utility3": "Signet of Undeath",
+              "elite": "Plaguelands"
+            }
+          }}
+        >
 
 
       Note that the build does not rely on precision as much as Power builds and you can build your Agony Resistance around the 150 breakpoint. You should however aim for a fully +9 stated infusion gear setup for maximum <Item id="79722"/> stat conversion value. Situational Runes:  

--- a/builds/necromancer/power-reaper/index.md
+++ b/builds/necromancer/power-reaper/index.md
@@ -26,102 +26,97 @@ sections:
     title: Equipment
     content: |-
       <CharacterWithAr> 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Necromancer",
-                  "weight":"Light", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 19212,
-                  "Armor": 2210,
-                  "Power": 4060,
-                  "Precision": 2304,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 1406,
-                  "Condition Damage": 500,
-                  "Expertise": 0,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.870952380952381,
-                  "Critical Damage": 2.4373333333333335,
-                  "Effective Power": 25980.256646773483,
-                  "Power DPS": 23709.360128168333,
-                  "Burning Damage": 325.78125,
-                  "Burning Stacks": 1.9,
-                  "Burning DPS": 618.984375,
-                  "Bleeding Damage": 81.25,
-                  "Bleeding Stacks": 39.9,
-                  "Bleeding DPS": 3241.875,
-                  "Poison Damage": 99.21875,
-                  "Poison Stacks": 2.7,
-                  "Poison DPS": 267.890625,
-                  "Torment Damage": 120,
-                  "Torment Stacks": 3.9,
-                  "Torment DPS": 468,
-                  "Confusion Damage": 81.25,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 28306.110128168333,
-                  "Effective Health": 53073150,
-                  "Survivability": 26981.77427554652,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Greatsword",
-                  "weapon1MainSigil1": "force",
-                  "weapon1MainSigil2": "impact",
-                  "weapon2MainType": "Axe",
-                  "weapon2MainSigil1": "force",
-                  "weapon2OffType": "Warhorn",
-                  "weapon2OffSigil": "impact"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Signet of Vampirism",
-                  "utility2": "Well of Suffering",
-                  "utility3": "Signet of Spite",
-                  "elite": "Lich Form"
-                } 
-              }}
-      > 
+      
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Necromancer",
+          "weight": "Light",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 19212,
+            "Armor": 2210,
+            "Power": 4060,
+            "Precision": 2304,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 1406,
+            "Condition Damage": 500,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.870952380952381,
+            "Critical Damage": 2.4373333333333335,
+            "Effective Power": 25980.256646773483,
+            "Power DPS": 23709.360128168333,
+            "Burning Damage": 325.78125,
+            "Burning Stacks": 1.9,
+            "Burning DPS": 618.984375,
+            "Bleeding Damage": 81.25,
+            "Bleeding Stacks": 39.9,
+            "Bleeding DPS": 3241.875,
+            "Poison Damage": 99.21875,
+            "Poison Stacks": 2.7,
+            "Poison DPS": 267.890625,
+            "Torment Damage": 120,
+            "Torment Stacks": 3.9,
+            "Torment DPS": 468,
+            "Confusion Damage": 81.25,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 28306.110128168333,
+            "Effective Health": 53073150,
+            "Survivability": 26981.77427554652,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Greatsword",
+            "weapon1MainSigil1": "force",
+            "weapon1MainSigil2": "impact",
+            "weapon2MainType": "Axe",
+            "weapon2MainSigil1": "force",
+            "weapon2OffType": "Warhorn",
+            "weapon2OffSigil": "impact"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Signet of Vampirism",
+            "utility2": "Well of Suffering",
+            "utility3": "Signet of Spite",
+            "elite": "Lich Form"
+          }
+        }}
+      >
 
       You will be crit-capped in <Skill name="Reapers Shroud"/>. 
 

--- a/builds/ranger/condi-soulbeast/index.md
+++ b/builds/ranger/condi-soulbeast/index.md
@@ -31,205 +31,192 @@ sections:
   - type: null
     title: Equipment
     content: >-
-      <CharacterWithAr>  
+      <CharacterWithAr>
 
-      <Character title="Krait Runes" 
-                 gear={{ "profession": "Ranger",
-                  "weight":"Light", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 17122,
-                  "Armor": 2361,
-                  "Power": 2923,
-                  "Precision": 1976,
-                  "Toughness": 1243,
-                  "Vitality": 1120,
-                  "Ferocity": 150,
-                  "Condition Damage": 3023,
-                  "Expertise": 773,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.5153333333333333,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.8147619047619048,
-                  "Critical Damage": 1.60,
-                  "Bleeding Duration": 0.50,
-                  "Effective Power": 8601.860511160714,
-                  "Power DPS": 5051.150280908775,
-                  "Burning Damage": 974.2931250000001,
-                  "Burning Stacks": 3.4852666666666665,
-                  "Burning DPS": 3395.6713521250003,
-                  "Bleeding Damage": 439.55502500000006,
-                  "Bleeding Stacks": 51.8,
-                  "Bleeding DPS": 22768.950295000002,
-                  "Poison Damage": 436.475,
-                  "Poison Stacks": 23.336133333333336,
-                  "Poison DPS": 10185.638796666668,
-                  "Torment Damage": 493.78875,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 330.4925,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 41401.41072470044,
-                  "Effective Health": 50531302.5,
-                  "Survivability": 25689.52846975089,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24762, "runeName":"Krait", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Short Bow",
-                  "weapon1MainSigil1": "bursting",
-                  "weapon1MainSigil2": "earth",
-                  "weapon2MainType": "Dagger",
-                  "weapon2MainSigil1": "bursting",
-                  "weapon2OffType": "Torch",
-                  "weapon2OffSigil": "earth"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-focusing-crystal",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "We Heal as One",
-                  "utility2": "Sharpening Stone",
-                  "utility3": "Vulture Stance",
-                  "elite": "One Wolf Pack"
-                } 
-              }}
-      /> 
+      <Character
+        title="Krait Runes"
+        gear={{
+          "profession": "Ranger",
+          "weight": "Light",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 17122,
+            "Armor": 2361,
+            "Power": 2923,
+            "Precision": 1976,
+            "Toughness": 1243,
+            "Vitality": 1120,
+            "Ferocity": 150,
+            "Condition Damage": 3023,
+            "Expertise": 773,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.5153333333333333,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.8147619047619048,
+            "Critical Damage": 1.6,
+            "Bleeding Duration": 0.5,
+            "Effective Power": 8601.860511160714,
+            "Power DPS": 5051.150280908775,
+            "Burning Damage": 974.2931250000001,
+            "Burning Stacks": 3.4852666666666665,
+            "Burning DPS": 3395.6713521250003,
+            "Bleeding Damage": 439.55502500000006,
+            "Bleeding Stacks": 51.8,
+            "Bleeding DPS": 22768.950295000002,
+            "Poison Damage": 436.475,
+            "Poison Stacks": 23.336133333333336,
+            "Poison DPS": 10185.638796666668,
+            "Torment Damage": 493.78875,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 330.4925,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 41401.41072470044,
+            "Effective Health": 50531302.5,
+            "Survivability": 25689.52846975089,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24762,
+          "runeName": "Krait",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Short Bow",
+            "weapon1MainSigil1": "bursting",
+            "weapon1MainSigil2": "earth",
+            "weapon2MainType": "Dagger",
+            "weapon2MainSigil1": "bursting",
+            "weapon2OffType": "Torch",
+            "weapon2OffSigil": "earth"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "toxic-focusing-crystal",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "We Heal as One",
+            "utility2": "Sharpening Stone",
+            "utility3": "Vulture Stance",
+            "elite": "One Wolf Pack"
+          }
+        }}
+      />
 
-      <Character title="Afflicted Runes" 
-                 gear={{ "profession": "Ranger",
-                  "weight":"Light", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 17122,
-                  "Armor": 2361,
-                  "Power": 2923,
-                  "Precision": 1976,
-                  "Toughness": 1243,
-                  "Vitality": 1120,
-                  "Ferocity": 150,
-                  "Condition Damage": 2885,
-                  "Expertise": 893,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.7953333333333333,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.8147619047619048,
-                  "Critical Damage": 1.60,
-                  "Bleeding Duration": 0.20,
-                  "Poison Duration": 0.10,
-                  "Effective Power": 8601.860511160714,
-                  "Power DPS": 5051.150280908775,
-                  "Burning Damage": 903.3984374999999,
-                  "Burning Stacks": 4.129266666666666,
-                  "Burning DPS": 3730.373054687499,
-                  "Bleeding Damage": 405.44218750000005,
-                  "Bleeding Stacks": 51.67913333333333,
-                  "Bleeding DPS": 20952.900866770837,
-                  "Poison Damage": 403.515625,
-                  "Poison Stacks": 29.188133333333333,
-                  "Poison DPS": 11777.867864583333,
-                  "Torment Damage": 455.390625,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 304.84375,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 41512.292066950446,
-                  "Effective Health": 50531302.5,
-                  "Survivability": 25689.52846975089,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24687, "runeName":"Afflicted", "infusions":[
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113,
-                  86113
-              ], "weapons":{
-                  "weapon1MainType": "Short Bow",
-                  "weapon1MainSigil1": "malice",
-                  "weapon1MainSigil2": "earth",
-                  "weapon2MainType": "Dagger",
-                  "weapon2MainSigil1": "malice",
-                  "weapon2OffType": "Torch",
-                  "weapon2OffSigil": "earth"
-              }, "consumables":{
-                  "foodId": "91876",
-                  "utility": "toxic-focusing-crystal",
-                  "infusion": "Spiteful +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "We Heal as One",
-                  "utility2": "Sharpening Stone",
-                  "utility3": "Vulture Stance",
-                  "elite": "One Wolf Pack"
-                } 
-              }}
-      >  
-
+      <Character
+        title="Afflicted Runes"
+        gear={{
+          "profession": "Ranger",
+          "weight": "Light",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 17122,
+            "Armor": 2361,
+            "Power": 2923,
+            "Precision": 1976,
+            "Toughness": 1243,
+            "Vitality": 1120,
+            "Ferocity": 150,
+            "Condition Damage": 2885,
+            "Expertise": 893,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.7953333333333333,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.8147619047619048,
+            "Critical Damage": 1.6,
+            "Bleeding Duration": 0.2,
+            "Poison Duration": 0.1,
+            "Effective Power": 8601.860511160714,
+            "Power DPS": 5051.150280908775,
+            "Burning Damage": 903.3984374999999,
+            "Burning Stacks": 4.129266666666666,
+            "Burning DPS": 3730.373054687499,
+            "Bleeding Damage": 405.44218750000005,
+            "Bleeding Stacks": 51.67913333333333,
+            "Bleeding DPS": 20952.900866770837,
+            "Poison Damage": 403.515625,
+            "Poison Stacks": 29.188133333333333,
+            "Poison DPS": 11777.867864583333,
+            "Torment Damage": 455.390625,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 304.84375,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 41512.292066950446,
+            "Effective Health": 50531302.5,
+            "Survivability": 25689.52846975089,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24687,
+          "runeName": "Afflicted",
+          "infusions": [
+            86113, 86113, 86113, 86113, 86113, 86113, 86113,
+            86113, 86113, 86113, 86113, 86113, 86113, 86113,
+            86113, 86113, 86113, 86113
+          ],
+          "weapons": {
+            "weapon1MainType": "Short Bow",
+            "weapon1MainSigil1": "malice",
+            "weapon1MainSigil2": "earth",
+            "weapon2MainType": "Dagger",
+            "weapon2MainSigil1": "malice",
+            "weapon2OffType": "Torch",
+            "weapon2OffSigil": "earth"
+          },
+          "consumables": {
+            "foodId": "91876",
+            "utility": "toxic-focusing-crystal",
+            "infusion": "Spiteful +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "We Heal as One",
+            "utility2": "Sharpening Stone",
+            "utility3": "Vulture Stance",
+            "elite": "One Wolf Pack"
+          }
+        }}
+      >
 
       This builds damage depends on the amount of <Specialization name="Soulbeast" text="Condi Soulbeasts"/> in the party. The build deals similar DPS with 2 <Specialization name="Soulbeast" text="Condi Soulbeasts"/>, and outperforms the Krait build if you have 3 <Specialization name="Soulbeast" text="Condi Soulbeasts"/> in the party. If you are going to be on your own run the Krait rune setup!  
 

--- a/builds/ranger/power-soulbeast/index.md
+++ b/builds/ranger/power-soulbeast/index.md
@@ -45,102 +45,96 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Ranger",
-                  "weight":"Medium", "gear":[
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Berserker",
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 17422,
-                  "Armor": 2511,
-                  "Power": 3675,
-                  "Precision": 2575,
-                  "Toughness": 1393,
-                  "Vitality": 1150,
-                  "Ferocity": 2106,
-                  "Condition Damage": 900,
-                  "Expertise": 0,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.904,
-                  "Effective Power": 34752.53438459952,
-                  "Power DPS": 37201.40376942113,
-                  "Burning Damage": 422.65625,
-                  "Burning Stacks": 0.67,
-                  "Burning DPS": 283.1796875,
-                  "Bleeding Damage": 118.75,
-                  "Bleeding Stacks": 4.5,
-                  "Bleeding DPS": 534.375,
-                  "Poison Damage": 136.71875,
-                  "Poison Stacks": 2.4,
-                  "Poison DPS": 328.125,
-                  "Torment Damage": 176.25,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.75,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 38347.08345692113,
-                  "Effective Health": 60151632.75,
-                  "Survivability": 30580.39285714286,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Longbow",
-                  "weapon1MainSigil1": "force",
-                  "weapon1MainSigil2": "impact",
-                  "weapon2MainType": "Sword",
-                  "weapon2MainSigil1": "force",
-                  "weapon2OffType": "Axe",
-                  "weapon2OffSigil": "impact"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "We Heal as One",
-                  "utility2": "Sic Em",
-                  "utility3": "Frost Spirit",
-                  "elite": "One Wolf Pack"
-                } 
-              }}
-      >  
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Ranger",
+          "weight": "Medium",
+          "gear": [
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 17422,
+            "Armor": 2511,
+            "Power": 3675,
+            "Precision": 2575,
+            "Toughness": 1393,
+            "Vitality": 1150,
+            "Ferocity": 2106,
+            "Condition Damage": 900,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.162,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.904,
+            "Effective Power": 34752.53438459952,
+            "Power DPS": 37201.40376942113,
+            "Burning Damage": 422.65625,
+            "Burning Stacks": 0.67,
+            "Burning DPS": 283.1796875,
+            "Bleeding Damage": 118.75,
+            "Bleeding Stacks": 4.5,
+            "Bleeding DPS": 534.375,
+            "Poison Damage": 136.71875,
+            "Poison Stacks": 2.4,
+            "Poison DPS": 328.125,
+            "Torment Damage": 176.25,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.75,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 38347.08345692113,
+            "Effective Health": 60151632.75,
+            "Survivability": 30580.39285714286,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Longbow",
+            "weapon1MainSigil1": "force",
+            "weapon1MainSigil2": "impact",
+            "weapon2MainType": "Sword",
+            "weapon2MainSigil1": "force",
+            "weapon2OffType": "Axe",
+            "weapon2OffSigil": "impact"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "We Heal as One",
+            "utility2": "Sic Em",
+            "utility3": "Frost Spirit",
+            "elite": "One Wolf Pack"
+          }
+        }}
+      >
 
 
       If you are going to play without <Trait name="Spotter"/> or <Skill name="Banner of Discipline"/> you will be missing 100 precision. To [crit cap](/guides/crit-cap/) you can either adjust your gear using our gear optimizer linked below, or simply use <Item id="12486"/>.
@@ -151,102 +145,96 @@ sections:
 
       </Character> 
 
-      <Character title="222 Agony Resistance" 
-                 gear={{ "profession": "Ranger",
-                  "weight":"Medium", "gear":[
-                  "Assassin",
-                  "Assassin",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 17422,
-                  "Armor": 2601,
-                  "Power": 3765,
-                  "Precision": 2575,
-                  "Toughness": 1483,
-                  "Vitality": 1150,
-                  "Ferocity": 2106,
-                  "Condition Damage": 900,
-                  "Expertise": 0,
-                  "Concentration": 333,
-                  "Healing Power": 0,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.222,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.904,
-                  "Effective Power": 35603.61685932441,
-                  "Power DPS": 38112.45855561103,
-                  "Burning Damage": 422.65625,
-                  "Burning Stacks": 0.67,
-                  "Burning DPS": 283.1796875,
-                  "Bleeding Damage": 118.75,
-                  "Bleeding Stacks": 4.5,
-                  "Bleeding DPS": 534.375,
-                  "Poison Damage": 136.71875,
-                  "Poison Stacks": 2.4,
-                  "Poison DPS": 328.125,
-                  "Torment Damage": 176.25,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.75,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 39258.13824311103,
-                  "Effective Health": 62307605.25,
-                  "Survivability": 31676.464285714286,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Longbow",
-                  "weapon1MainSigil1": "force",
-                  "weapon1MainSigil2": "impact",
-                  "weapon2MainType": "Sword",
-                  "weapon2MainSigil1": "force",
-                  "weapon2OffType": "Axe",
-                  "weapon2OffSigil": "impact"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "We Heal as One",
-                  "utility2": "Sic Em",
-                  "utility3": "Frost Spirit",
-                  "elite": "One Wolf Pack"
-                } 
-              }}
-      >  
+      <Character
+        title="222 Agony Resistance"
+        gear={{
+          "profession": "Ranger",
+          "weight": "Medium",
+          "gear": [
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 17422,
+            "Armor": 2601,
+            "Power": 3765,
+            "Precision": 2575,
+            "Toughness": 1483,
+            "Vitality": 1150,
+            "Ferocity": 2106,
+            "Condition Damage": 900,
+            "Expertise": 0,
+            "Concentration": 333,
+            "Healing Power": 0,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.222,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.904,
+            "Effective Power": 35603.61685932441,
+            "Power DPS": 38112.45855561103,
+            "Burning Damage": 422.65625,
+            "Burning Stacks": 0.67,
+            "Burning DPS": 283.1796875,
+            "Bleeding Damage": 118.75,
+            "Bleeding Stacks": 4.5,
+            "Bleeding DPS": 534.375,
+            "Poison Damage": 136.71875,
+            "Poison Stacks": 2.4,
+            "Poison DPS": 328.125,
+            "Torment Damage": 176.25,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.75,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 39258.13824311103,
+            "Effective Health": 62307605.25,
+            "Survivability": 31676.464285714286,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Longbow",
+            "weapon1MainSigil1": "force",
+            "weapon1MainSigil2": "impact",
+            "weapon2MainType": "Sword",
+            "weapon2MainSigil1": "force",
+            "weapon2OffType": "Axe",
+            "weapon2OffSigil": "impact"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "We Heal as One",
+            "utility2": "Sic Em",
+            "utility3": "Frost Spirit",
+            "elite": "One Wolf Pack"
+          }
+        }}
+      >
 
 
       You need <Item id="85743"/>, <Item id="86175"/>, 18x +9 Agony Infusions and also <Item id="70596"/>. <br/>
@@ -259,102 +247,96 @@ sections:
 
       </Character>  
 
-      <Character title="243 Agony Resistance" 
-                 gear={{ "profession": "Ranger",
-                  "weight":"Medium", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker"
-              ], "attributes":{
-                  "Health": 17422,
-                  "Armor": 2632,
-                  "Power": 3781,
-                  "Precision": 2575,
-                  "Toughness": 1514,
-                  "Vitality": 1150,
-                  "Ferocity": 2106,
-                  "Condition Damage": 900,
-                  "Expertise": 0,
-                  "Concentration": 364,
-                  "Healing Power": 0,
-                  "Agony Resistance": 243,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.24266666666666666,
-                  "Critical Chance": 1.00,
-                  "Critical Damage": 2.904,
-                  "Effective Power": 35896.76748950742,
-                  "Power DPS": 38426.266315298664,
-                  "Burning Damage": 422.65625,
-                  "Burning Stacks": 0.67,
-                  "Burning DPS": 283.1796875,
-                  "Bleeding Damage": 118.75,
-                  "Bleeding Stacks": 4.5,
-                  "Bleeding DPS": 534.375,
-                  "Poison Damage": 136.71875,
-                  "Poison Stacks": 2.4,
-                  "Poison DPS": 328.125,
-                  "Torment Damage": 176.25,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.75,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 39571.946002798664,
-                  "Effective Health": 63050218,
-                  "Survivability": 32054,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  49437,
-                  49437,
-                  49438,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Longbow",
-                  "weapon1MainSigil1": "force",
-                  "weapon1MainSigil2": "impact",
-                  "weapon2MainType": "Sword",
-                  "weapon2MainSigil1": "force",
-                  "weapon2OffType": "Axe",
-                  "weapon2OffSigil": "impact"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "We Heal as One",
-                  "utility2": "Sic Em",
-                  "utility3": "Frost Spirit",
-                  "elite": "One Wolf Pack"
-                } 
-              }}
-      > 
+      <Character
+        title="243 Agony Resistance"
+        gear={{
+          "profession": "Ranger",
+          "weight": "Medium",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 17422,
+            "Armor": 2632,
+            "Power": 3781,
+            "Precision": 2575,
+            "Toughness": 1514,
+            "Vitality": 1150,
+            "Ferocity": 2106,
+            "Condition Damage": 900,
+            "Expertise": 0,
+            "Concentration": 364,
+            "Healing Power": 0,
+            "Agony Resistance": 243,
+            "Condition Duration": 0,
+            "Boon Duration": 0.24266666666666666,
+            "Critical Chance": 1.0,
+            "Critical Damage": 2.904,
+            "Effective Power": 35896.76748950742,
+            "Power DPS": 38426.266315298664,
+            "Burning Damage": 422.65625,
+            "Burning Stacks": 0.67,
+            "Burning DPS": 283.1796875,
+            "Bleeding Damage": 118.75,
+            "Bleeding Stacks": 4.5,
+            "Bleeding DPS": 534.375,
+            "Poison Damage": 136.71875,
+            "Poison Stacks": 2.4,
+            "Poison DPS": 328.125,
+            "Torment Damage": 176.25,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.75,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 39571.946002798664,
+            "Effective Health": 63050218,
+            "Survivability": 32054,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 49437, 49437, 49438, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Longbow",
+            "weapon1MainSigil1": "force",
+            "weapon1MainSigil2": "impact",
+            "weapon2MainType": "Sword",
+            "weapon2MainSigil1": "force",
+            "weapon2OffType": "Axe",
+            "weapon2OffSigil": "impact"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "We Heal as One",
+            "utility2": "Sic Em",
+            "utility3": "Frost Spirit",
+            "elite": "One Wolf Pack"
+          }
+        }}
+      >
 
 
       You need <Item id="85743"/>, <Item id="86175"/>, 2x <Item id="49437"/> and 1x <Item id="49438"/>, with the rest being 15x +9 Agony Infusions. You also need <Item id="70596"/> and the 5 AR from _Mistlock Singularity_. <br/>

--- a/builds/revenant/condi-alac-renegade/index.md
+++ b/builds/revenant/condi-alac-renegade/index.md
@@ -19,101 +19,95 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="80% Boon Duration 162 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Viper",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Viper",
-                  "Viper",
-                  "Celestial",
-                  "Viper",
-                  "Viper",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial"
-              ], "attributes":{
-                  "Health": 20572,
-                  "Armor": 2979,
-                  "Power": 2602,
-                  "Precision": 1916,
-                  "Toughness": 1708,
-                  "Vitality": 1465,
-                  "Ferocity": 615,
-                  "Condition Damage": 2068,
-                  "Expertise": 743,
-                  "Concentration": 827,
-                  "Healing Power": 465,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.7453333333333333,
-                  "Boon Duration": 0.8013333333333333,
-                  "Critical Chance": 1.0161904761904762,
-                  "Critical Damage": 1.91,
-                  "Bleeding Duration": 0.25,
-                  "Effective Power": 9821.3738146875,
-                  "Power DPS": 11262.245367785667,
-                  "Burning Damage": 747.8631250000001,
-                  "Burning Stacks": 7.330400000000001,
-                  "Burning DPS": 5482.135851500001,
-                  "Bleeding Damage": 302.43125,
-                  "Bleeding Stacks": 26.138866666666665,
-                  "Bleeding DPS": 7905.210119583332,
-                  "Poison Damage": 260.991875,
-                  "Poison Stacks": 7.854,
-                  "Poison DPS": 2049.8301862499998,
-                  "Torment Damage": 397.023,
-                  "Torment Stacks": 29.147066666666667,
-                  "Torment DPS": 11572.055849200002,
-                  "Confusion Damage": 241.94499999999996,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 38271.477374319,
-                  "Effective Health": 101884630.05000001,
-                  "Survivability": 51796.96494661922,
-                  "Effective Healing": 529.5,
-                  "Healing": 529.5
-              }, "runeId":70600, "runeName":"Leadership", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Mace",
-                  "weapon1MainSigil1": "earth",
-                  "weapon1OffType": "Axe",
-                  "weapon1OffSigil": "doom",
-                  "weapon2MainType": "Short Bow",
-                  "weapon2MainSigil1": "torment",
-                  "weapon2MainSigil2": "geomancy"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-maintenance-oil",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "legends": {
-                "legend1": "legendarydemonstance",
-                "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="80% Boon Duration 162 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Viper",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Viper",
+            "Viper",
+            "Celestial",
+            "Viper",
+            "Viper",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial"
+          ],
+          "attributes": {
+            "Health": 20572,
+            "Armor": 2979,
+            "Power": 2602,
+            "Precision": 1916,
+            "Toughness": 1708,
+            "Vitality": 1465,
+            "Ferocity": 615,
+            "Condition Damage": 2068,
+            "Expertise": 743,
+            "Concentration": 827,
+            "Healing Power": 465,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.7453333333333333,
+            "Boon Duration": 0.8013333333333333,
+            "Critical Chance": 1.0161904761904762,
+            "Critical Damage": 1.91,
+            "Bleeding Duration": 0.25,
+            "Effective Power": 9821.3738146875,
+            "Power DPS": 11262.245367785667,
+            "Burning Damage": 747.8631250000001,
+            "Burning Stacks": 7.330400000000001,
+            "Burning DPS": 5482.135851500001,
+            "Bleeding Damage": 302.43125,
+            "Bleeding Stacks": 26.138866666666665,
+            "Bleeding DPS": 7905.210119583332,
+            "Poison Damage": 260.991875,
+            "Poison Stacks": 7.854,
+            "Poison DPS": 2049.8301862499998,
+            "Torment Damage": 397.023,
+            "Torment Stacks": 29.147066666666667,
+            "Torment DPS": 11572.055849200002,
+            "Confusion Damage": 241.94499999999996,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 38271.477374319,
+            "Effective Health": 101884630.05000001,
+            "Survivability": 51796.96494661922,
+            "Effective Healing": 529.5,
+            "Healing": 529.5
+          },
+          "runeId": 70600,
+          "runeName": "Leadership",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Mace",
+            "weapon1MainSigil1": "earth",
+            "weapon1OffType": "Axe",
+            "weapon1OffSigil": "doom",
+            "weapon2MainType": "Short Bow",
+            "weapon2MainSigil1": "torment",
+            "weapon2MainSigil2": "geomancy"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "toxic-maintenance-oil",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendarydemonstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       For more variations to suit your needs/Agony Resistance check our [Gear Optimizer](https://discretize.github.io/discretize-gear-optimizer/). If you have a <Specialization name="Soulbeast"/> that has <Skill id="45970"/>, you can play Condi DPS Renegade and take <Item id="91847"/> and <Item id="48916"/>, you want to aim for just over 30% boon duration. 
@@ -121,101 +115,95 @@ sections:
 
       </Character>  
 
-      <Character title="80% Boon Duration 222 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Celestial",
-                  "Viper",
-                  "Celestial",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Celestial",
-                  "Viper",
-                  "Viper",
-                  "Celestial",
-                  "Celestial"
-              ], "attributes":{
-                  "Health": 19592,
-                  "Armor": 2971,
-                  "Power": 2687,
-                  "Precision": 2003,
-                  "Toughness": 1700,
-                  "Vitality": 1367,
-                  "Ferocity": 517,
-                  "Condition Damage": 2166,
-                  "Expertise": 740,
-                  "Concentration": 826,
-                  "Healing Power": 367,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0.7433333333333334,
-                  "Boon Duration": 0.8006666666666666,
-                  "Critical Chance": 1.0576190476190476,
-                  "Critical Damage": 1.8446666666666667,
-                  "Bleeding Duration": 0.25,
-                  "Effective Power": 9795.28661596875,
-                  "Power DPS": 11232.330975107792,
-                  "Burning Damage": 773.0215625000001,
-                  "Burning Stacks": 7.322000000000001,
-                  "Burning DPS": 5660.063880625001,
-                  "Bleeding Damage": 314.6046875,
-                  "Bleeding Stacks": 26.112666666666666,
-                  "Bleeding DPS": 8215.167336458333,
-                  "Poison Damage": 270.73062500000003,
-                  "Poison Stacks": 7.845000000000001,
-                  "Poison DPS": 2123.8817531250006,
-                  "Torment Damage": 413.0919375000001,
-                  "Torment Stacks": 29.113666666666667,
-                  "Torment DPS": 12026.620971062503,
-                  "Confusion Damage": 251.68375,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 39258.06491637863,
-                  "Effective Health": 96770520.7,
-                  "Survivability": 49197.01103202847,
-                  "Effective Healing": 500.1,
-                  "Healing": 500.1
-              }, "runeId":70600, "runeName":"Leadership", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Mace",
-                  "weapon1MainSigil1": "earth",
-                  "weapon1OffType": "Axe",
-                  "weapon1OffSigil": "doom",
-                  "weapon2MainType": "Short Bow",
-                  "weapon2MainSigil1": "torment",
-                  "weapon2MainSigil2": "geomancy"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-maintenance-oil",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "legends": {
-                "legend1": "legendarydemonstance",
-                "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="80% Boon Duration 222 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Celestial",
+            "Viper",
+            "Celestial",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Celestial",
+            "Viper",
+            "Viper",
+            "Celestial",
+            "Celestial"
+          ],
+          "attributes": {
+            "Health": 19592,
+            "Armor": 2971,
+            "Power": 2687,
+            "Precision": 2003,
+            "Toughness": 1700,
+            "Vitality": 1367,
+            "Ferocity": 517,
+            "Condition Damage": 2166,
+            "Expertise": 740,
+            "Concentration": 826,
+            "Healing Power": 367,
+            "Agony Resistance": 222,
+            "Condition Duration": 0.7433333333333334,
+            "Boon Duration": 0.8006666666666666,
+            "Critical Chance": 1.0576190476190476,
+            "Critical Damage": 1.8446666666666667,
+            "Bleeding Duration": 0.25,
+            "Effective Power": 9795.28661596875,
+            "Power DPS": 11232.330975107792,
+            "Burning Damage": 773.0215625000001,
+            "Burning Stacks": 7.322000000000001,
+            "Burning DPS": 5660.063880625001,
+            "Bleeding Damage": 314.6046875,
+            "Bleeding Stacks": 26.112666666666666,
+            "Bleeding DPS": 8215.167336458333,
+            "Poison Damage": 270.73062500000003,
+            "Poison Stacks": 7.845000000000001,
+            "Poison DPS": 2123.8817531250006,
+            "Torment Damage": 413.0919375000001,
+            "Torment Stacks": 29.113666666666667,
+            "Torment DPS": 12026.620971062503,
+            "Confusion Damage": 251.68375,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 39258.06491637863,
+            "Effective Health": 96770520.7,
+            "Survivability": 49197.01103202847,
+            "Effective Healing": 500.1,
+            "Healing": 500.1
+          },
+          "runeId": 70600,
+          "runeName": "Leadership",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Mace",
+            "weapon1MainSigil1": "earth",
+            "weapon1OffType": "Axe",
+            "weapon1OffSigil": "doom",
+            "weapon2MainType": "Short Bow",
+            "weapon2MainSigil1": "torment",
+            "weapon2MainSigil2": "geomancy"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "toxic-maintenance-oil",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendarydemonstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       For more variations to suit your needs/Agony Resistance check our [Gear Optimizer](https://discretize.github.io/discretize-gear-optimizer/). If you have a <Specialization name="Soulbeast"/> that has <Skill id="45970"/>, you can play Condi DPS Renegade and take <Item id="91847"/> and <Item id="48916"/>, you want to aim for just over 30% boon duration. 
@@ -223,101 +211,95 @@ sections:
 
       </Character>  
 
-      <Character title="Condi DPS Renegade" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2514,
-                  "Power": 2923,
-                  "Precision": 1876,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 150,
-                  "Condition Damage": 2633,
-                  "Expertise": 703,
-                  "Concentration": 243,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.8186666666666667,
-                  "Boon Duration": 0.162,
-                  "Critical Chance": 0.9971428571428572,
-                  "Critical Damage": 1.60,
-                  "Bleeding Duration": 0.25,
-                  "Effective Power": 9625.272571687501,
-                  "Power DPS": 11044.787163507413,
-                  "Burning Damage": 926.60390625,
-                  "Burning Stacks": 8.365866666666665,
-                  "Burning DPS": 7751.844732499999,
-                  "Bleeding Damage": 386.67578125,
-                  "Bleeding Stacks": 27.4,
-                  "Bleeding DPS": 10594.916406249999,
-                  "Poison Damage": 329.10625,
-                  "Poison Stacks": 8.911466666666668,
-                  "Poison DPS": 2932.819376666667,
-                  "Torment Damage": 508.14328125,
-                  "Torment Stacks": 33.281600000000005,
-                  "Torment DPS": 16911.82142925,
-                  "Confusion Damage": 309.340625,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 49236.189108174076,
-                  "Effective Health": 50034885,
-                  "Survivability": 25437.155566853075,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24848, "runeName":"Nightmare", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Mace",
-                  "weapon1MainSigil1": "earth",
-                  "weapon1OffType": "Axe",
-                  "weapon1OffSigil": "doom",
-                  "weapon2MainType": "Short Bow",
-                  "weapon2MainSigil1": "geomancy",
-                  "weapon2MainSigil2": "torment"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "toxic-focusing-crystal",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "legends": {
-                "legend1": "legendarydemonstance",
-                "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="Condi DPS Renegade"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2514,
+            "Power": 2923,
+            "Precision": 1876,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 150,
+            "Condition Damage": 2633,
+            "Expertise": 703,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.8186666666666667,
+            "Boon Duration": 0.162,
+            "Critical Chance": 0.9971428571428572,
+            "Critical Damage": 1.6,
+            "Bleeding Duration": 0.25,
+            "Effective Power": 9625.272571687501,
+            "Power DPS": 11044.787163507413,
+            "Burning Damage": 926.60390625,
+            "Burning Stacks": 8.365866666666665,
+            "Burning DPS": 7751.844732499999,
+            "Bleeding Damage": 386.67578125,
+            "Bleeding Stacks": 27.4,
+            "Bleeding DPS": 10594.916406249999,
+            "Poison Damage": 329.10625,
+            "Poison Stacks": 8.911466666666668,
+            "Poison DPS": 2932.819376666667,
+            "Torment Damage": 508.14328125,
+            "Torment Stacks": 33.281600000000005,
+            "Torment DPS": 16911.82142925,
+            "Confusion Damage": 309.340625,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 49236.189108174076,
+            "Effective Health": 50034885,
+            "Survivability": 25437.155566853075,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24848,
+          "runeName": "Nightmare",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Mace",
+            "weapon1MainSigil1": "earth",
+            "weapon1OffType": "Axe",
+            "weapon1OffSigil": "doom",
+            "weapon2MainType": "Short Bow",
+            "weapon2MainSigil1": "geomancy",
+            "weapon2MainSigil2": "torment"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "toxic-focusing-crystal",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendarydemonstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       If you have 2 <Specialization name="Renegade" text="Condi Renegades"/> you can both play <Trait name="Righteous Rebel"/> to provide <Boon name="alacrity"/>, 

--- a/builds/revenant/power-renegade/index.md
+++ b/builds/revenant/power-renegade/index.md
@@ -23,100 +23,94 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="80% Boon Duration 162 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner",
-                  "Diviner",
-                  "Diviner"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2514,
-                  "Power": 3327,
-                  "Precision": 2037,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 1139,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 1204,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.8026666666666667,
-                  "Critical Chance": 1.0738095238095238,
-                  "Critical Damage": 2.2593333333333334,
-                  "Effective Power": 25745.248386407973,
-                  "Power DPS": 36610.39749364831,
-                  "Burning Damage": 438.86875,
-                  "Burning Stacks": 1.7,
-                  "Burning DPS": 746.076875,
-                  "Bleeding Damage": 118.925,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 139.3375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 176.2575,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.925,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 37356.474368648305,
-                  "Effective Health": 55038373.5,
-                  "Survivability": 27980.87112353838,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1": "force",
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigil": "impact",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "force",
-                  "weapon2MainSigil2": "severance"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                 "legends": {
-                  "legend1": "legendaryassassinstance",
-                  "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      > 
+      <Character
+        title="80% Boon Duration 162 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Diviner",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Diviner",
+            "Diviner",
+            "Diviner"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2514,
+            "Power": 3327,
+            "Precision": 2037,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 1139,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 1204,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.8026666666666667,
+            "Critical Chance": 1.0738095238095238,
+            "Critical Damage": 2.2593333333333334,
+            "Effective Power": 25745.248386407973,
+            "Power DPS": 36610.39749364831,
+            "Burning Damage": 438.86875,
+            "Burning Stacks": 1.7,
+            "Burning DPS": 746.076875,
+            "Bleeding Damage": 118.925,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 139.3375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 176.2575,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.925,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 37356.474368648305,
+            "Effective Health": 55038373.5,
+            "Survivability": 27980.87112353838,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "force",
+            "weapon1OffType": "Sword",
+            "weapon1OffSigil": "impact",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "force",
+            "weapon2MainSigil2": "severance"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendaryassassinstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!
@@ -126,100 +120,94 @@ sections:
 
       </Character>  
 
-      <Character title="50% Boon Duration 162 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2514,
-                  "Power": 3413,
-                  "Precision": 2158,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 1260,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 755,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.50333333333333336,
-                  "Critical Chance": 1.1314285714285714,
-                  "Critical Damage": 2.34,
-                  "Effective Power": 27353.702627550432,
-                  "Power DPS": 38897.660301711105,
-                  "Burning Damage": 438.86875,
-                  "Burning Stacks": 1.7,
-                  "Burning DPS": 746.076875,
-                  "Bleeding Damage": 118.925,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 139.3375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 176.2575,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.925,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 39643.7371767111,
-                  "Effective Health": 55038373.5,
-                  "Survivability": 27980.87112353838,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1": "force",
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigil": "impact",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "force",
-                  "weapon2MainSigil2": "severance"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                 "legends": {
-                  "legend1": "legendaryassassinstance",
-                  "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="50% Boon Duration 162 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Diviner",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Diviner",
+            "Diviner"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2514,
+            "Power": 3413,
+            "Precision": 2158,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 1260,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 755,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.50333333333333336,
+            "Critical Chance": 1.1314285714285714,
+            "Critical Damage": 2.34,
+            "Effective Power": 27353.702627550432,
+            "Power DPS": 38897.660301711105,
+            "Burning Damage": 438.86875,
+            "Burning Stacks": 1.7,
+            "Burning DPS": 746.076875,
+            "Bleeding Damage": 118.925,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 139.3375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 176.2575,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.925,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 39643.7371767111,
+            "Effective Health": 55038373.5,
+            "Survivability": 27980.87112353838,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "force",
+            "weapon1OffType": "Sword",
+            "weapon1OffSigil": "impact",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "force",
+            "weapon2MainSigil2": "severance"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendaryassassinstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!
@@ -229,100 +217,94 @@ sections:
 
       </Character>  
 
-      <Character title="80% Boon Duration 222 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner",
-                  "Diviner",
-                  "Berserker",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner",
-                  "Diviner"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2604,
-                  "Power": 3345,
-                  "Precision": 2152,
-                  "Toughness": 1333,
-                  "Vitality": 1000,
-                  "Ferocity": 1164,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 1202,
-                  "Healing Power": 0,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.8013333333333334,
-                  "Critical Chance": 1.1285714285714286,
-                  "Critical Damage": 2.276,
-                  "Effective Power": 26075.48262151496,
-                  "Power DPS": 37079.9989685232,
-                  "Burning Damage": 438.86875,
-                  "Burning Stacks": 1.7,
-                  "Burning DPS": 746.076875,
-                  "Bleeding Damage": 118.925,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 139.3375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 176.2575,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.925,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 37826.0758435232,
-                  "Effective Health": 57008721,
-                  "Survivability": 28982.572953736653,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1": "force",
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigil": "impact",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "force",
-                  "weapon2MainSigil2": "severance"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                 "legends": {
-                  "legend1": "legendaryassassinstance",
-                  "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="80% Boon Duration 222 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Diviner",
+            "Diviner",
+            "Berserker",
+            "Berserker",
+            "Diviner",
+            "Diviner",
+            "Diviner"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2604,
+            "Power": 3345,
+            "Precision": 2152,
+            "Toughness": 1333,
+            "Vitality": 1000,
+            "Ferocity": 1164,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 1202,
+            "Healing Power": 0,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.8013333333333334,
+            "Critical Chance": 1.1285714285714286,
+            "Critical Damage": 2.276,
+            "Effective Power": 26075.48262151496,
+            "Power DPS": 37079.9989685232,
+            "Burning Damage": 438.86875,
+            "Burning Stacks": 1.7,
+            "Burning DPS": 746.076875,
+            "Bleeding Damage": 118.925,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 139.3375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 176.2575,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.925,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 37826.0758435232,
+            "Effective Health": 57008721,
+            "Survivability": 28982.572953736653,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "force",
+            "weapon1OffType": "Sword",
+            "weapon1OffSigil": "impact",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "force",
+            "weapon2MainSigil2": "severance"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendaryassassinstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!
@@ -331,100 +313,94 @@ sections:
 
       </Character>  
 
-      <Character title="50% Boon Duration 222 Agony Resistance" 
-                 gear={{ "profession": "Revenant",
-                  "weight":"Heavy", "gear":[
-                  "Berserker",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Diviner",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Berserker",
-                  "Diviner",
-                  "Diviner"
-              ], "attributes":{
-                  "Health": 15922,
-                  "Armor": 2604,
-                  "Power": 3429,
-                  "Precision": 2275,
-                  "Toughness": 1333,
-                  "Vitality": 1000,
-                  "Ferocity": 1287,
-                  "Condition Damage": 750,
-                  "Expertise": 0,
-                  "Concentration": 751,
-                  "Healing Power": 0,
-                  "Agony Resistance": 222,
-                  "Condition Duration": 0,
-                  "Boon Duration": 0.5006666666666667,
-                  "Critical Chance": 1.1871428571428572,
-                  "Critical Damage": 2.358,
-                  "Effective Power": 27693.335136228063,
-                  "Power DPS": 39380.62636045061,
-                  "Burning Damage": 438.86875,
-                  "Burning Stacks": 1.7,
-                  "Burning DPS": 746.076875,
-                  "Bleeding Damage": 118.925,
-                  "Bleeding Stacks": 0,
-                  "Bleeding DPS": 0,
-                  "Poison Damage": 139.3375,
-                  "Poison Stacks": 0,
-                  "Poison DPS": 0,
-                  "Torment Damage": 176.2575,
-                  "Torment Stacks": 0,
-                  "Torment DPS": 0,
-                  "Confusion Damage": 118.925,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 40126.70323545061,
-                  "Effective Health": 57008721,
-                  "Survivability": 28982.572953736653,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24836, "runeName":"Scholar", "infusions":[
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131,
-                  37131
-              ], "weapons":{
-                  "weapon1MainType": "Sword",
-                  "weapon1MainSigil1": "force",
-                  "weapon1OffType": "Sword",
-                  "weapon1OffSigil": "impact",
-                  "weapon2MainType": "Staff",
-                  "weapon2MainSigil1": "force",
-                  "weapon2MainSigil2": "severance"
-              }, "consumables":{
-                  "foodId": "91805",
-                  "utility": "superior-sharpening-stone",
-                  "infusion": "Mighty +9 Agony Infusion"
-              },
-                 "legends": {
-                  "legend1": "legendaryassassinstance",
-                  "legend2": "legendaryrenegadestance"
-                } 
-              }}
-      >  
+      <Character
+        title="50% Boon Duration 222 Agony Resistance"
+        gear={{
+          "profession": "Revenant",
+          "weight": "Heavy",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Diviner",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Diviner",
+            "Diviner"
+          ],
+          "attributes": {
+            "Health": 15922,
+            "Armor": 2604,
+            "Power": 3429,
+            "Precision": 2275,
+            "Toughness": 1333,
+            "Vitality": 1000,
+            "Ferocity": 1287,
+            "Condition Damage": 750,
+            "Expertise": 0,
+            "Concentration": 751,
+            "Healing Power": 0,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.5006666666666667,
+            "Critical Chance": 1.1871428571428572,
+            "Critical Damage": 2.358,
+            "Effective Power": 27693.335136228063,
+            "Power DPS": 39380.62636045061,
+            "Burning Damage": 438.86875,
+            "Burning Stacks": 1.7,
+            "Burning DPS": 746.076875,
+            "Bleeding Damage": 118.925,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 139.3375,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 176.2575,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 118.925,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 40126.70323545061,
+            "Effective Health": 57008721,
+            "Survivability": 28982.572953736653,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "infusions": [
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weapons": {
+            "weapon1MainType": "Sword",
+            "weapon1MainSigil1": "force",
+            "weapon1OffType": "Sword",
+            "weapon1OffSigil": "impact",
+            "weapon2MainType": "Staff",
+            "weapon2MainSigil1": "force",
+            "weapon2MainSigil2": "severance"
+          },
+          "consumables": {
+            "foodId": "91805",
+            "utility": "superior-sharpening-stone",
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "legends": {
+            "legend1": "legendaryassassinstance",
+            "legend2": "legendaryrenegadestance"
+          }
+        }}
+      >
 
 
       Check the [gear optimizer](https://discretize.github.io/discretize-gear-optimizer/) for more gear variants!

--- a/builds/thief/condi-deadeye/index.md
+++ b/builds/thief/condi-deadeye/index.md
@@ -48,101 +48,95 @@ sections:
     content: >-
       <CharacterWithAr>  
 
-      <Character title="162 Agony Resistance" 
-                 gear={{ "profession": "Thief",
-                  "weight":"Medium", "gear":[
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper",
-                  "Viper"
-              ], "attributes":{
-                  "Health": 11645,
-                  "Armor": 2361,
-                  "Power": 2923,
-                  "Precision": 1876,
-                  "Toughness": 1243,
-                  "Vitality": 1000,
-                  "Ferocity": 150,
-                  "Condition Damage": 2756,
-                  "Expertise": 853,
-                  "Concentration": 423,
-                  "Healing Power": 0,
-                  "Agony Resistance": 162,
-                  "Condition Duration": 0.7686666666666667,
-                  "Boon Duration": 0.282,
-                  "Critical Chance": 0.6671428571428572,
-                  "Critical Damage": 1.60,
-                  "Poison Duration": 0.33,
-                  "Effective Power": 9735.350599106787,
-                  "Power DPS": 6297.800926645899,
-                  "Burning Damage": 941.9287500000002,
-                  "Burning Stacks": 0.8843333333333334,
-                  "Burning DPS": 832.9789912500003,
-                  "Bleeding Damage": 395.2125,
-                  "Bleeding Stacks": 35.019600000000004,
-                  "Bleeding DPS": 13840.183665,
-                  "Poison Damage": 446.31641249999996,
-                  "Poison Stacks": 29.4,
-                  "Poison DPS": 13121.702527499998,
-                  "Torment Damage": 472.22999999999996,
-                  "Torment Stacks": 19.27846666666667,
-                  "Torment DPS": 9103.870314000002,
-                  "Confusion Damage": 316.16999999999996,
-                  "Confusion Stacks": 0,
-                  "Confusion DPS": 0,
-                  "Damage": 43196.5364243959,
-                  "Effective Health": 37804036.875,
-                  "Survivability": 19219.13415099136,
-                  "Effective Healing": 390,
-                  "Healing": 390
-              }, "runeId":24848, "runeName":"Nightmare", "infusions":[
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130,
-                  37130
-              ], "weapons":{
-                  "weapon1MainType": "Pistol",
-                  "weapon1MainSigil1": "bursting",
-                  "weapon1OffType": "Dagger",
-                  "weapon1OffSigil": "earth"
-              }, "consumables":{
-                  "foodId": "91878",
-                  "utility": "tuning-icicle",
-                  "infusion": "Malign +9 Agony Infusion"
-              },
-                "skills": {
-                  "heal": "Hide in Shadows",
-                  "utility1": "Mercy",
-                  "utility2": "Skale Venom",
-                  "utility3": "Spider Venom",
-                  "elite": "Shadow Meld"
-                } 
-              }}
-      >  
+      <Character
+        title="162 Agony Resistance"
+        gear={{
+          "profession": "Thief",
+          "weight": "Medium",
+          "gear": [
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper",
+            "Viper"
+          ],
+          "attributes": {
+            "Health": 11645,
+            "Armor": 2361,
+            "Power": 2923,
+            "Precision": 1876,
+            "Toughness": 1243,
+            "Vitality": 1000,
+            "Ferocity": 150,
+            "Condition Damage": 2756,
+            "Expertise": 853,
+            "Concentration": 423,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0.7686666666666667,
+            "Boon Duration": 0.282,
+            "Critical Chance": 0.6671428571428572,
+            "Critical Damage": 1.6,
+            "Poison Duration": 0.33,
+            "Effective Power": 9735.350599106787,
+            "Power DPS": 6297.800926645899,
+            "Burning Damage": 941.9287500000002,
+            "Burning Stacks": 0.8843333333333334,
+            "Burning DPS": 832.9789912500003,
+            "Bleeding Damage": 395.2125,
+            "Bleeding Stacks": 35.019600000000004,
+            "Bleeding DPS": 13840.183665,
+            "Poison Damage": 446.31641249999996,
+            "Poison Stacks": 29.4,
+            "Poison DPS": 13121.702527499998,
+            "Torment Damage": 472.22999999999996,
+            "Torment Stacks": 19.27846666666667,
+            "Torment DPS": 9103.870314000002,
+            "Confusion Damage": 316.16999999999996,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 43196.5364243959,
+            "Effective Health": 37804036.875,
+            "Survivability": 19219.13415099136,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "runeId": 24848,
+          "runeName": "Nightmare",
+          "infusions": [
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130, 37130, 37130, 37130,
+            37130, 37130, 37130, 37130
+          ],
+          "weapons": {
+            "weapon1MainType": "Pistol",
+            "weapon1MainSigil1": "bursting",
+            "weapon1OffType": "Dagger",
+            "weapon1OffSigil": "earth"
+          },
+          "consumables": {
+            "foodId": "91878",
+            "utility": "tuning-icicle",
+            "infusion": "Malign +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Hide in Shadows",
+            "utility1": "Mercy",
+            "utility2": "Skale Venom",
+            "utility3": "Spider Venom",
+            "elite": "Shadow Meld"
+          }
+        }}
+      >
 
 
       Note that there are two slightly different variants of this build: one is meant for bosses with very short phases such as Ensolyss or Light Ai; the other one is meant for longer fights, where you will need to sustain damage for a longer period of time. This will also depend on your group. It will always be better to use the latter with people you do not know well, or in situations where your party doesn't bring enough damage.

--- a/builds/warrior/power-berserker/index.md
+++ b/builds/warrior/power-berserker/index.md
@@ -19,109 +19,97 @@ sections:
     content: >-
       <CharacterWithAr> 
 
-      <Character title="162 Agony Resistance + Scholar Rune" gear={{
-        "profession": "warrior",
-        "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 21652,
-          "Armor": 2214,
-          "Power": 4205,
-          "Precision": 2575,
-          "Toughness": 943,
-          "Vitality": 1244,
-          "Ferocity": 2345,
-          "Condition Damage": 1200,
-          "Expertise": 0,
-          "Concentration": 243,
-          "Healing Power": 0,
-          "Agony Resistance": 162,
-          "Condition Duration": 0,
-          "Boon Duration": 0.162,
-          "Critical Chance": 1.00,
-          "Critical Damage": 3.0633333333333337,
-          "Effective Power": 37197.06737656876,
-          "Power DPS": 40677.578494206886,
-          "Burning Damage": 455.6875,
-          "Burning Stacks": 0.7,
-          "Burning DPS": 318.98125,
-          "Bleeding Damage": 135.125,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 151.65625,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 200.9625,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 135.125,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 40996.55974420688,
-          "Effective Health": 79696140.3,
-          "Survivability": 40516.593950177936,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432
-        ],
-        "weight": "Heavy",
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Axe",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Axe",
-          "weapon1OffSigilId": 24868,
-          "weapon2MainType": "Axe",
-          "weapon2MainSigil1": "Paralyzation",
-          "weapon2OffType": "Mace",
-          "weapon2OffSigil": "Severance"
-        },
-        "consumables": {
-          "foodId": 12486,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Mending",
-          "utility2": "Banner of Strength",
-          "utility3": "Banner of Discipline",
-          "elite": "Head Butt"
-        }
-      }}> 
+      <Character
+        title="162 Agony Resistance + Scholar Rune"
+        gear={{
+          "profession": "warrior",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 21652,
+            "Armor": 2214,
+            "Power": 4205,
+            "Precision": 2575,
+            "Toughness": 943,
+            "Vitality": 1244,
+            "Ferocity": 2345,
+            "Condition Damage": 1200,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.162,
+            "Critical Chance": 1.0,
+            "Critical Damage": 3.0633333333333337,
+            "Effective Power": 37197.06737656876,
+            "Power DPS": 40677.578494206886,
+            "Burning Damage": 455.6875,
+            "Burning Stacks": 0.7,
+            "Burning DPS": 318.98125,
+            "Bleeding Damage": 135.125,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 151.65625,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 200.9625,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 135.125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 40996.55974420688,
+            "Effective Health": 79696140.3,
+            "Survivability": 40516.593950177936,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            49432, 49432, 49432, 49432, 49432, 49432, 49432,
+            49432, 49432, 49432, 49432, 49432, 49432, 49432,
+            49432, 49432, 49432, 49432
+          ],
+          "weight": "Heavy",
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Axe",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Axe",
+            "weapon2MainSigil1": "Paralyzation",
+            "weapon2OffType": "Mace",
+            "weapon2OffSigil": "Severance"
+          },
+          "consumables": {
+            "foodId": 12486,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mending",
+            "utility2": "Banner of Strength",
+            "utility3": "Banner of Discipline",
+            "elite": "Head Butt"
+          }
+        }}
+      >
 
 
       This build is future proof for upgrading to higher <Attribute name="Agony Resistance"/> later without overwriting runes. However, most people would profit more from the <Item name="eagle" text="Eagle"/> rune build due to not relying on the <Item name="scholar" text="Scholar"/> buff. No <Trait name="Spotter"/> assumed. 
@@ -129,224 +117,199 @@ sections:
 
       </Character> 
 
-      <Character title="162 Agony Resistance + Eagle Rune" gear={{
-        "profession": "warrior",
-        "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 21652,
-          "Armor": 2214,
-          "Power": 4210,
-          "Precision": 2575,
-          "Toughness": 943,
-          "Vitality": 1244,
-          "Ferocity": 2345,
-          "Condition Damage": 1200,
-          "Expertise": 0,
-          "Concentration": 243,
-          "Healing Power": 0,
-          "Agony Resistance": 162,
-          "Condition Duration": 0,
-          "Boon Duration": 0.162,
-          "Critical Chance": 1.00,
-          "Critical Damage": 3.0633333333333337,
-          "Effective Power": 37241.296945387505,
-          "Power DPS": 40725.94660180998,
-          "Burning Damage": 455.6875,
-          "Burning Stacks": 0.7,
-          "Burning DPS": 318.98125,
-          "Bleeding Damage": 135.125,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 151.65625,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 200.9625,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 135.125,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 41044.927851809975,
-          "Effective Health": 79696140.3,
-          "Survivability": 40516.593950177936,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37132,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432,
-          49432
-        ],
-        "weight": "Heavy",
-        "runeId": 24723,
-        "runeName": "Eagle",
-        "weapons": {
-          "weapon1MainType": "Axe",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Axe",
-          "weapon1OffSigilId": 24868,
-          "weapon2MainType": "Axe",
-          "weapon2MainSigil1": "Paralyzation",
-          "weapon2OffType": "Mace",
-          "weapon2OffSigil": "Severance"
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Mending",
-          "utility2": "Banner of Strength",
-          "utility3": "Banner of Discipline",
-          "elite": "Head Butt"
-        },
-        "skills": {
-          "heal": "Mending",
-          "utility2": "Banner of Strength",
-          "utility3": "Banner of Discipline",
-          "elite": "Head Butt"
-        }
-      }}> 
+      <Character
+        title="162 Agony Resistance + Eagle Rune"
+        gear={{
+          "profession": "warrior",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 21652,
+            "Armor": 2214,
+            "Power": 4210,
+            "Precision": 2575,
+            "Toughness": 943,
+            "Vitality": 1244,
+            "Ferocity": 2345,
+            "Condition Damage": 1200,
+            "Expertise": 0,
+            "Concentration": 243,
+            "Healing Power": 0,
+            "Agony Resistance": 162,
+            "Condition Duration": 0,
+            "Boon Duration": 0.162,
+            "Critical Chance": 1.0,
+            "Critical Damage": 3.0633333333333337,
+            "Effective Power": 37241.296945387505,
+            "Power DPS": 40725.94660180998,
+            "Burning Damage": 455.6875,
+            "Burning Stacks": 0.7,
+            "Burning DPS": 318.98125,
+            "Bleeding Damage": 135.125,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 151.65625,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 200.9625,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 135.125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 41044.927851809975,
+            "Effective Health": 79696140.3,
+            "Survivability": 40516.593950177936,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37132, 49432, 49432, 49432, 49432, 49432, 49432,
+            49432, 49432, 49432, 49432, 49432, 49432, 49432,
+            49432, 49432, 49432, 49432
+          ],
+          "weight": "Heavy",
+          "runeId": 24723,
+          "runeName": "Eagle",
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Axe",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Axe",
+            "weapon2MainSigil1": "Paralyzation",
+            "weapon2OffType": "Mace",
+            "weapon2OffSigil": "Severance"
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mending",
+            "utility2": "Banner of Strength",
+            "utility3": "Banner of Discipline",
+            "elite": "Head Butt"
+          },
+          "skills": {
+            "heal": "Mending",
+            "utility2": "Banner of Strength",
+            "utility3": "Banner of Discipline",
+            "elite": "Head Butt"
+          }
+        }}
+      > 
 
 
       Optionally 1 <Item id="37132"/>. Without that infusion the <Attribute name="Critical Chance"/> is at 99.76%. No <Trait name="Spotter"/> assumed. 
 
       </Character> 
 
-      <Character gear={{
-        "profession": "warrior",
-        "gear": [
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Assassin",
-          "Berserker",
-          "Berserker",
-          "Berserker"
-        ],
-        "attributes": {
-          "Health": 21832,
-          "Armor": 2304,
-          "Power": 4383,
-          "Precision": 2575,
-          "Toughness": 1033,
-          "Vitality": 1262,
-          "Ferocity": 2351,
-          "Condition Damage": 1200,
-          "Expertise": 0,
-          "Concentration": 333,
-          "Healing Power": 0,
-          "Agony Resistance": 222,
-          "Condition Duration": 0,
-          "Boon Duration": 0.222,
-          "Critical Chance": 1.00,
-          "Critical Damage": 3.0673333333333335,
-          "Effective Power": 38822.26675995676,
-          "Power DPS": 42454.84697661809,
-          "Burning Damage": 455.6875,
-          "Burning Stacks": 0.7,
-          "Burning DPS": 318.98125,
-          "Bleeding Damage": 135.125,
-          "Bleeding Stacks": 0,
-          "Bleeding DPS": 0,
-          "Poison Damage": 151.65625,
-          "Poison Stacks": 0,
-          "Poison DPS": 0,
-          "Torment Damage": 200.9625,
-          "Torment Stacks": 0,
-          "Torment DPS": 0,
-          "Confusion Damage": 135.125,
-          "Confusion Stacks": 0,
-          "Confusion DPS": 0,
-          "Damage": 42773.82822661809,
-          "Effective Health": 83625292.8,
-          "Survivability": 42514.12953736655,
-          "Effective Healing": 390,
-          "Healing": 390
-        },
-        "infusions": [
-          37132,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131,
-          37131
-        ],
-        "weight": "Heavy",
-        "runeId": 24836,
-        "runeName": "Scholar",
-        "weapons": {
-          "weapon1MainType": "Axe",
-          "weapon1MainSigil1Id": 24615,
-          "weapon1OffType": "Axe",
-          "weapon1OffSigilId": 24868,
-          "weapon2MainType": "Axe",
-          "weapon2MainSigil1": "Paralyzation",
-          "weapon2OffType": "Mace",
-          "weapon2OffSigil": "Severance"
-        },
-        "consumables": {
-          "foodId": 91805,
-          "utilityId": 9443,
-          "infusion": "Mighty +9 Agony Infusion"
-        },
-        "skills": {
-          "heal": "Mending",
-          "utility2": "Banner of Strength",
-          "utility3": "Banner of Discipline",
-          "elite": "Head Butt"
-        }
-      }}> 
+      <Character
+        gear={{
+          "profession": "warrior",
+          "gear": [
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Assassin",
+            "Berserker",
+            "Berserker",
+            "Berserker"
+          ],
+          "attributes": {
+            "Health": 21832,
+            "Armor": 2304,
+            "Power": 4383,
+            "Precision": 2575,
+            "Toughness": 1033,
+            "Vitality": 1262,
+            "Ferocity": 2351,
+            "Condition Damage": 1200,
+            "Expertise": 0,
+            "Concentration": 333,
+            "Healing Power": 0,
+            "Agony Resistance": 222,
+            "Condition Duration": 0,
+            "Boon Duration": 0.222,
+            "Critical Chance": 1.0,
+            "Critical Damage": 3.0673333333333335,
+            "Effective Power": 38822.26675995676,
+            "Power DPS": 42454.84697661809,
+            "Burning Damage": 455.6875,
+            "Burning Stacks": 0.7,
+            "Burning DPS": 318.98125,
+            "Bleeding Damage": 135.125,
+            "Bleeding Stacks": 0,
+            "Bleeding DPS": 0,
+            "Poison Damage": 151.65625,
+            "Poison Stacks": 0,
+            "Poison DPS": 0,
+            "Torment Damage": 200.9625,
+            "Torment Stacks": 0,
+            "Torment DPS": 0,
+            "Confusion Damage": 135.125,
+            "Confusion Stacks": 0,
+            "Confusion DPS": 0,
+            "Damage": 42773.82822661809,
+            "Effective Health": 83625292.8,
+            "Survivability": 42514.12953736655,
+            "Effective Healing": 390,
+            "Healing": 390
+          },
+          "infusions": [
+            37132, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131, 37131, 37131, 37131,
+            37131, 37131, 37131, 37131
+          ],
+          "weight": "Heavy",
+          "runeId": 24836,
+          "runeName": "Scholar",
+          "weapons": {
+            "weapon1MainType": "Axe",
+            "weapon1MainSigil1Id": 24615,
+            "weapon1OffType": "Axe",
+            "weapon1OffSigilId": 24868,
+            "weapon2MainType": "Axe",
+            "weapon2MainSigil1": "Paralyzation",
+            "weapon2OffType": "Mace",
+            "weapon2OffSigil": "Severance"
+          },
+          "consumables": {
+            "foodId": 91805,
+            "utilityId": 9443,
+            "infusion": "Mighty +9 Agony Infusion"
+          },
+          "skills": {
+            "heal": "Mending",
+            "utility2": "Banner of Strength",
+            "utility3": "Banner of Discipline",
+            "elite": "Head Butt"
+          }
+        }}
+      >
 
 
       Optionally 1 <Item id="37132"/>. Without that infusion the <Attribute name="Critical Chance"/> is at 99.76%. No <Trait name="Spotter"/> assumed.


### PR DESCRIPTION
This shouldn't change any builds, it should just fix the indentation and such in the `<Character />` elements in the build pages.

Assuming I did this correctly, this should match the format that is created when you directly paste the output of the optimizer into the CMS, I hope. Then, any updates to these builds will hopefully have a clean diff.

Edit: had to PR a change to the optimizer (`#346`) such that that would work.